### PR TITLE
p2p: support for pre-steps on execute-command reusable workflow

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -5,14 +5,13 @@ on:
     branches:
       - main
 
-
 concurrency: cd-main
 
-  
 jobs:
   p2p:
     uses: ./.github/workflows/p2p.yaml
     with:
+      env-name: test-env
       project-id: PROJECT-ID
       project-number: PROJECT-NUMBER
       tenant-name: TEST-TENANT

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,10 +7,10 @@ on:
 
 jobs:
   increment-version:
-    uses: ./.github/workflows/increment-version.yaml   
+    uses: ./.github/workflows/increment-version.yaml
     secrets:
       git-token: ${{ secrets.GITHUB_TOKEN }}
-    with: 
+    with:
       dry-run: true
 
   test_execute_command:
@@ -19,6 +19,7 @@ jobs:
       env_vars: |
         TEST_VARIABLE=value
     with:
+      env-name: test-env
       command: test-var-print
       workload-identity-provider: WORKLOAD_IP
       service-account: SERVICE_ACCOUNT
@@ -28,11 +29,27 @@ jobs:
   test_execute_command_without_env_vars:
     uses: ./.github/workflows/execute-command.yaml
     with:
+      env-name: test-env
       command: p2p-build
       workload-identity-provider: WORKLOAD_IP
       service-account: SERVICE_ACCOUNT
       project-id: TEST-TENANT
       dry-run: true
+
+  test_execute_command_with_pre_post_steps:
+    uses: ./.github/workflows/execute-command.yaml
+    secrets:
+      env_vars: |
+        SOME_SECRET=123
+    with:
+      env-name: test-env
+      command: p2p-build
+      workload-identity-provider: WORKLOAD_IP
+      service-account: SERVICE_ACCOUNT
+      project-id: TEST-TENANT
+      dry-run: true
+      pre-targets: test-pre-step
+      post-targets: test-post-step
 
   p2p:
     uses: ./.github/workflows/p2p.yaml
@@ -40,8 +57,8 @@ jobs:
       env_vars: |
         TEST_VARIABLE=value
     with:
+      env-name: test-env
       project-id: PROJECT-ID
       project-number: PROJECT-NUMBER
       tenant-name: TEST-TENANT
       dry-run: true
-

--- a/.github/workflows/execute-command.yaml
+++ b/.github/workflows/execute-command.yaml
@@ -7,14 +7,14 @@ on:
         required: false
     inputs:
       command:
-        required: true 
+        required: true
         type: string
       project-id:
         required: true
         type: string
       env-name:
         required: true
-        type: string  
+        type: string
       workload-identity-provider:
         required: true
         type: string
@@ -33,6 +33,18 @@ on:
         required: false
         type: string
         default: europe-west2-a
+      pre-targets:
+        description: |
+          Make targets to run before the command
+        required: false
+        type: string
+        default: ''
+      post-targets:
+        description: |
+          Make targets to run after the command
+        required: false
+        type: string
+        default: ''
 env:
   REGISTRY: ${{ inputs.region }}-docker.pkg.dev/${{ inputs.project-id }}/tenant
 
@@ -91,7 +103,7 @@ jobs:
         run: |
           gcloud container clusters get-credentials --project ${{ inputs.project-id }} --zone ${{ inputs.region }} --internal-ip ${{ inputs.env-name }}
           kubectl config set clusters.gke_${{ inputs.project-id }}_${{ inputs.region }}_${{ inputs.env-name }}.proxy-url http://localhost:57755
-    
+
       - name: Test kubectl
         id: test-kubectl
         if: inputs.dry-run == false
@@ -114,7 +126,17 @@ jobs:
             printf '%s\n' $i >> $GITHUB_ENV
           done
 
+      - name: Pre-targets
+        if: inputs.pre-targets != ''
+        run: |
+          make ${{ inputs.pre-targets }}
+
       - name: Run Command
         id: run-command
         run: |
           make ${{ inputs.command }}
+
+      - name: Post-targets
+        if: inputs.post-targets != ''
+        run: |
+          make ${{ inputs.post-targets }}

--- a/.github/workflows/p2p.yaml
+++ b/.github/workflows/p2p.yaml
@@ -39,7 +39,7 @@ jobs:
     outputs:
       workflow_identity_provider: ${{ steps.setup.outputs.workflow_identity_provider }}
       service_account: ${{ steps.setup.outputs.service_account }}
-    steps:   
+    steps:
       - name: Setup inputs passed to the reusable workflow
         id: setup
         run: |

--- a/Makefile
+++ b/Makefile
@@ -7,11 +7,11 @@ help:
 
 # P2P tasks
 
-.PHONY: p2p-build 
+.PHONY: p2p-build
 p2p-build: ## Build phase
 	echo "##### EXECUTING P2P-BUILD #####"
 
-.PHONY: p2p-functional 
+.PHONY: p2p-functional
 p2p-functional: ## Execute functional tests
 	echo "##### EXECUTING P2P-FUNCTIONAL #####"
 
@@ -23,6 +23,14 @@ p2p-nft:  ## Execute non-functional tests
 p2p-dev:  ## Deploys to dev environment
 	echo "##### EXECUTING P2P-DEV #####"
 
-.PHONY: test-var-print 
+.PHONY: test-var-print
 test-var-print :## Test task
 	echo $${TEST_VARIABLE}
+
+.PHONY: test-pre-step
+test-pre-step:## Test pre-step
+	echo "##### EXECUTING TEST-PRE-TASK $${SOME_SECRET} #####"
+
+.PHONY: test-post-step
+test-post-step:## Test post-step
+	echo "##### EXECUTING TEST-POST-TASK $${SOME_SECRET} #####"


### PR DESCRIPTION
Allows you to execute arbitrary Make targets either side of the desired p2p command.

Required by the intergo usecase for additional registry logins before a command is run.