### PR TITLE
Fix: Inject Secrets in P2P Promote Image

### DIFF
--- a/.github/workflows/p2p-promote-image.yaml
+++ b/.github/workflows/p2p-promote-image.yaml
@@ -69,6 +69,7 @@ jobs:
     needs: [lookup]
     environment: ${{ inputs.dest_github_env }}
     env:
+      env_vars: ${{ secrets.env_vars }}
       BASE_DOMAIN: ${{ vars.BASE_DOMAIN }}
       DEST_GITHUB_ENV: ${{ inputs.dest_github_env }}
       DPLATFORM: ${{ vars.DPLATFORM }}


### PR DESCRIPTION
## Summary

Added missing env variable so the secrets are available in the makefile target

## Details

We're already decoding the `env_vars` in the `promote-image` job (see https://github.com/coreeng/p2p/blob/0dbab356ec86d2e2d17e1e92b3d402f2ccb7d390/.github/workflows/p2p-promote-image.yaml#L152) but the secrets are not being passed

This issue currently prevents the underlying `p2p-promote-to-XXXX:` from consuming other secrets which we required in our project
