### PR TITLE
add auth-azure step for vendor azure to platform-execute-command

### DIFF
--- a/.github/workflows/platform-execute-command.yaml
+++ b/.github/workflows/platform-execute-command.yaml
@@ -70,6 +70,15 @@ jobs:
           role-to-assume: ${{ vars.AWS_ROLE_ARN }}
           aws-region: ${{ vars.AWS_REGION }}
 
+      - id: auth-azure
+        if: inputs.platform == 'azure'
+        name: Authenticate to Azure
+        uses: azure/login@v2
+        with:
+          client-id: ${{ vars.AZURE_CLIENT_ID }}
+          tenant-id: ${{ vars.AZURE_TENANT_ID }}
+          subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
+
       - id: auth-gcloud
         if: inputs.platform == 'gcp'
         name: Authenticate to GCP


### PR DESCRIPTION
This adds an `auth-azure` step that will be run when `platform` is set to `azure` only, and performs a similar function to the `auth-aws` and `auth-gcp`.