### PR TITLE
Pin azure-auth to 1.5.1 

### DIFF
--- a/.github/workflows/platform-execute-command.yaml
+++ b/.github/workflows/platform-execute-command.yaml
@@ -73,7 +73,7 @@ jobs:
       - id: auth-azure
         if: inputs.platform == 'azure'
         name: Authenticate to Azure
-        uses: azure/login@v2
+        uses: azure/login@v1.5.1
         with:
           client-id: ${{ vars.AZURE_CLIENT_ID }}
           tenant-id: ${{ vars.AZURE_TENANT_ID }}


### PR DESCRIPTION
Later versions cause warnings and have issues with some github runners:
https://github.com/Azure/login/issues/403

This was fixed in 1.6.1, but reintroduced in 2.x

There's an issue to make pre/post steps disableable (we definitely don't need pre, and post is harmless but not needed if the main one didn't run) so until that's addressed it's best to leave it at the last working version.