### PR TITLE
Promote image when the trigger is a tag

### DIFF
--- a/.github/workflows/p2p-workflow-fastfeedback.yaml
+++ b/.github/workflows/p2p-workflow-fastfeedback.yaml
@@ -89,7 +89,7 @@ jobs:
   promote:
     name: promote
     needs: [nft-test, functional-test]
-    if: success() && github.ref == inputs.main-branch
+    if: success() && (github.ref == inputs.main-branch || github.ref_type == 'tag' ))
     secrets:
       env_vars: ${{ secrets.env_vars }}
     uses: ./.github/workflows/p2p-promote-image.yaml


### PR DESCRIPTION
all other main branch comparisons are either in the version workflows or the ones triggered by crons, so no need to add this there