### PR TITLE
set ARM_* variables to get terraform azure provider to use OIDC

### DIFF
--- a/.github/workflows/platform-execute-command.yaml
+++ b/.github/workflows/platform-execute-command.yaml
@@ -40,6 +40,10 @@ jobs:
       ENV: ${{ inputs.environment }}
       PLATFORM: ${{ inputs.platform }}
       TERRAFORM_ARGS: "-auto-approve"
+      ARM_USE_OIDC: true
+      ARM_CLIENT_ID: ${{ vars.AZURE_CLIENT_ID }}
+      ARM_TENANT_ID: ${{ vars.AZURE_TENANT_ID }}
+      ARM_SUBSCRIPTION_ID: ${{ vars.AZURE_SUBSCRIPTION_ID }}
 
     permissions:
       contents: read


### PR DESCRIPTION
Terraform provider for Azure expects these ARM_* env variables to use OIDC, and they're harmless if set to null for everything else.