### PR TITLE
Fix missing space

### DIFF
--- a/.github/workflows/p2p-version.yaml
+++ b/.github/workflows/p2p-version.yaml
@@ -116,7 +116,7 @@ jobs:
             echo "Tag already exists on this commit, setting previous version"
             echo "version=${PREVIOUS_TAG}" >> "$GITHUB_OUTPUT"
         else
-            if ["${{ inputs.main-branch }}" = "${{ github.ref }}" ]; then
+            if [ "${{ inputs.main-branch }}" = "${{ github.ref }}" ]; then
                 echo "On main branch, setting next version"
                 echo "version=${TAG}" >> "$GITHUB_OUTPUT"
             else


### PR DESCRIPTION
This was causing a broken condition `'[refs/heads/main' = refs/heads/main ']'` and the condition would never be true.