### PR TITLE
Fix last commit hash calculation

### DIFF
--- a/.github/workflows/p2p-version.yaml
+++ b/.github/workflows/p2p-version.yaml
@@ -82,8 +82,8 @@ jobs:
         if [ -n "$GITHUB_HEAD_REF" ]; then
             GIT_REF="origin/$GITHUB_HEAD_REF"
         fi
-        HASH=$(git rev-parse --short ${GIT_REF})
-        LAST_TAG_HASH=$(git rev-parse --short ${VERSION_PREFIX}${PREVIOUS_TAG}^{} || echo "does-not-exist" )
+        HASH=$(git rev-parse ${GIT_REF})
+        LAST_TAG_HASH=$(git rev-list -n 1 ${VERSION_PREFIX}${PREVIOUS_TAG} || echo "does-not-exist" )
 
         echo "current_hash=${HASH}" >> "$GITHUB_OUTPUT"
         echo "previous_tag_hash=${LAST_TAG_HASH}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/p2p-version.yaml
+++ b/.github/workflows/p2p-version.yaml
@@ -31,9 +31,6 @@ jobs:
   increment-version:
     name: increment-version
     runs-on: ubuntu-latest
-    concurrency:
-      group: version-concurrency
-      cancel-in-progress: false
     outputs:
       version: ${{ steps.setversion.outputs.version }}
       previous_version: ${{ steps.setversion.outputs.previous_version }}
@@ -86,7 +83,7 @@ jobs:
             GIT_REF="origin/$GITHUB_HEAD_REF"
         fi
         HASH=$(git rev-parse --short ${GIT_REF})
-        LAST_TAG_HASH=$(git rev-parse --short ${VERSION_PREFIX}${PREVIOUS_TAG} || echo "does-not-exist" )
+        LAST_TAG_HASH=$(git rev-parse --short ${VERSION_PREFIX}${PREVIOUS_TAG}^{} || echo "does-not-exist" )
 
         echo "current_hash=${HASH}" >> "$GITHUB_OUTPUT"
         echo "previous_tag_hash=${LAST_TAG_HASH}" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
Fixes a couple of issues
Tags
```
git rev-parse --short refs/heads/main 
7ab24b9
```
This was my main branch hash


```
git rev-parse --short v0.0.13           
6c8e84a
```
This was the tag hash, even though they were created in the same commit


```
git show-ref --tags -d          
1495246ff17048ac43489dcd5ba8cb258ba377d6 refs/tags/v0.0.1
c9bbf797fecb0cda87bea702e5de01ab7474d196 refs/tags/v0.0.1^{}
9933b3e1948fa84fa2966d74d3651518d57a95c7 refs/tags/v0.0.10
6ae7d2dd53e52bbe688300a49edebf5e71d02251 refs/tags/v0.0.10^{}
59f71686e00d0457ffd4d91cc27483b475cd0646 refs/tags/v0.0.11
9dc7240d92694b0046bcca95710cf5f1a2cc3fd4 refs/tags/v0.0.11^{}
36f07edfca93d3c28831001d8b9ecc1a71c275a5 refs/tags/v0.0.12
d860b61209c696893445d0d4bb66d0043553d334 refs/tags/v0.0.12^{}
6c8e84af7e9ba51f8fcc27dc3a49a51ceb66020e refs/tags/v0.0.13
7ab24b986f8128bf92a3f56c04689380a8e6f6c3 refs/tags/v0.0.13^{}
d584a3e041ff2ed643db6fd09921fbcaf1ee174e refs/tags/v0.0.2
c9bbf797fecb0cda87bea702e5de01ab7474d196 refs/tags/v0.0.2^{}
c509854f42a72d56d949c30f919cf035779ce514 refs/tags/v0.0.3
c9bbf797fecb0cda87bea702e5de01ab7474d196 refs/tags/v0.0.3^{}
b972932373f25cd7852b1a887773063f61cbd73b refs/tags/v0.0.4
19e698ce87f99a18f165bafe43b30e286f4f618b refs/tags/v0.0.4^{}
7f30386e275b580d54c129a905dcbfc8282a7562 refs/tags/v0.0.5
19e698ce87f99a18f165bafe43b30e286f4f618b refs/tags/v0.0.5^{}
740763ac1b4618de0ea108fea5593ae9ad62e54e refs/tags/v0.0.6
776bb570105815734e43ec31adaddbee5bfd6fc8 refs/tags/v0.0.6^{}
187b3224452c661d5ef048e857c2a742187a2fa6 refs/tags/v0.0.7
776bb570105815734e43ec31adaddbee5bfd6fc8 refs/tags/v0.0.7^{}
c9537bb10903ba2c3a39b59382bd55b25a6530da refs/tags/v0.0.8
0fd4a8161c09568b2bfd6e11bb3179ea777c2882 refs/tags/v0.0.8^{}
4344cf62b377c90bae80655c6788b9ab6d3c3e27 refs/tags/v0.0.9
a17e391f1b1faf7a53e1d2e37d0da9012c44f60e refs/tags/v0.0.9^{}
```

this has the correct hash.


Concurrency has been removed because even though it did not work as intended. Cancel-in-progress works only for the already in progress and not for the pending ones