### PR TITLE
Add environments validate to CI and CD workflows

### DIFF
--- a/.github/workflows/platform-cd.yaml
+++ b/.github/workflows/platform-cd.yaml
@@ -45,8 +45,6 @@ jobs:
             environments:
               - 'environments/**'
 
-            
-
   tenants:
     name: tenants
     uses: ./.github/workflows/platform-execute-command.yaml
@@ -84,7 +82,7 @@ jobs:
   feature:
     name: Feature
     uses: ./.github/workflows/platform-execute-command.yaml
-    needs: [changes, matrix]
+    needs: [changes, environments-validate, matrix]
     if: ${{ inputs.release_build == true || needs.changes.outputs.environments == 'true' }}
     secrets:
       cecg-registry-username: ${{ secrets.cecg-registry-username }}

--- a/.github/workflows/platform-ci.yaml
+++ b/.github/workflows/platform-ci.yaml
@@ -81,7 +81,7 @@ jobs:
   feature:
     name: Feature
     uses: ./.github/workflows/platform-execute-command.yaml
-    needs: [changes, matrix]
+    needs: [changes, environments-validate, matrix]
     if: ${{ inputs.release_build == true || needs.changes.outputs.environments == 'true' }}
     secrets:
       cecg-registry-username: ${{ secrets.cecg-registry-username }}


### PR DESCRIPTION
This allows us to centralise environments validation with tenants. Uses https://github.com/coreeng/developer-platform/pull/518 for validation 