### PR TITLE
Install corectl in promote image job

### DIFF
--- a/.github/workflows/p2p-promote-image.yaml
+++ b/.github/workflows/p2p-promote-image.yaml
@@ -42,6 +42,9 @@ on:
       checkout-version:
         required: false
         type: string
+      corectl-version:
+        required: false
+        type: string
 
 
 jobs:
@@ -149,6 +152,27 @@ jobs:
         run: |
           gcloud container clusters get-credentials --project $PROJECT_ID --zone ${{ inputs.region }} --internal-ip ${{ env.DPLATFORM }}
           kubectl config set clusters.gke_${{ env.PROJECT_ID }}_${{ inputs.region }}_${{ env.DPLATFORM }}.proxy-url http://localhost:57755
+
+      - name: Setup corectl
+        id: setup-corectl
+        if: inputs.dry-run == false
+        env:
+          CORECTL_VERSION: ${{ inputs.corectl-version }}
+        run: |
+          if [ -z "$CORECTL_VERSION" ]; then
+          echo "No version specified, finding latest release"
+            CORECTL_VERSION=$(curl -s https://api.github.com/repos/coreeng/corectl/releases/latest | grep '"tag_name":' | cut -d'"' -f4)
+          fi
+          echo "Downloading version $CORECTL_VERSION"
+          RELEASE_URL="https://github.com/coreeng/corectl/releases/download/${CORECTL_VERSION}/corectl_Linux_x86_64.tar.gz"
+
+          curl -L $RELEASE_URL -o corectl.tar.gz
+          tar -xzf corectl.tar.gz
+          chmod +x corectl
+          sudo mv corectl /usr/local/bin/
+          rm corectl.tar.gz
+          
+          corectl help
 
       - name: Decode environment variables
         run: |

--- a/.github/workflows/p2p-workflow-extended-test.yaml
+++ b/.github/workflows/p2p-workflow-extended-test.yaml
@@ -36,6 +36,9 @@ on:
         required: false
         type: string
         default: 'v'
+      corectl-version:
+        required: false
+        type: string
 
 env:
   REGION: ${{ inputs.region }} 
@@ -74,3 +77,4 @@ jobs:
       dry-run: ${{ inputs.dry-run }}
       working-directory: ${{ inputs.working-directory }}
       checkout-version: ${{ inputs.version-prefix }}${{ inputs.version }}
+      corectl-version: ${{ inputs.corectl-version }}

--- a/.github/workflows/p2p-workflow-fastfeedback.yaml
+++ b/.github/workflows/p2p-workflow-fastfeedback.yaml
@@ -36,6 +36,9 @@ on:
         required: false
         type: string
         default: '.'
+      corectl-version:
+        required: false
+        type: string
     outputs:
       version:
         value: ${{ inputs.version }}
@@ -112,5 +115,6 @@ jobs:
       dry-run: ${{ inputs.dry-run }}
       working-directory: ${{ inputs.working-directory }}
       connect-to-k8s: true
+      corectl-version: ${{ inputs.corectl-version }}
 
 


### PR DESCRIPTION
Installs corectl in promote job. It can be then used in clients makefiles during promote stage, i.e. `corectl p2p promote ...`

The step is part of `fast-feedback` and `extended-test` stages. It adds about `2s` to job duration. 

When invoking you can pass parameter `corectl-version` to specify the version or leave blank for the latest to be installed.


## Tests

`fast-feedback` with `corectl-version: v0.18.1` 
 
![CleanShot 2024-08-02 at 10 07 24@2x](https://github.com/user-attachments/assets/9fd056b7-f0e9-4ed9-8893-d6edd2bb6495)


`fast-feedback` without specifying `corectl-version`
![CleanShot 2024-08-02 at 09 44 12@2x](https://github.com/user-attachments/assets/a7a9b1d9-f8b1-49b7-9ff1-a1bf22523de0)


