### PR TITLE
Switch app workflows from ubuntu-latest to ubuntu-24.04

### DIFF
--- a/.github/workflows/bump-version.yaml
+++ b/.github/workflows/bump-version.yaml
@@ -13,7 +13,7 @@ jobs:
       git-token: ${{ secrets.GITHUB_TOKEN }}
 
   fail:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     if: github.event.action == 'failure'
     steps:
       - name: Exit with error

--- a/.github/workflows/internal-cd.yaml
+++ b/.github/workflows/internal-cd.yaml
@@ -18,7 +18,7 @@ jobs:
       generate-minor: false
 
   trigger-p2p-build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: [internal-version]
     env:
       ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}

--- a/.github/workflows/internal-ci.yaml
+++ b/.github/workflows/internal-ci.yaml
@@ -36,7 +36,7 @@ jobs:
     with:
       dry-run: true
     uses: ./.github/workflows/p2p-version.yaml
-    
+
   test_execute_command:
     needs: [test_version]
     uses: ./.github/workflows/p2p-execute-command.yaml
@@ -70,7 +70,7 @@ jobs:
 
   test_extended_test:
     uses: ./.github/workflows/p2p-workflow-extended-test.yaml
-    needs: [get_image_extended_test] 
+    needs: [get_image_extended_test]
     secrets:
       env_vars: |
         TEST_VARIABLE=value

--- a/.github/workflows/internal-ci.yaml
+++ b/.github/workflows/internal-ci.yaml
@@ -14,7 +14,7 @@ jobs:
       dry-run: true
 
   print-version:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: increment-version
     steps:
       - env:

--- a/.github/workflows/internal-version.yaml
+++ b/.github/workflows/internal-version.yaml
@@ -1,4 +1,3 @@
-
 name: increment-version
 
 on:
@@ -30,22 +29,22 @@ jobs:
     runs-on: ubuntu-24.04
     outputs:
       version: ${{ steps.setversion.outputs.patch }}
-      
+
     steps:
     - uses: actions/checkout@v4
       with:
-        fetch-depth: 0  
+        fetch-depth: 0
     - name: Configure Git
       run: |
         git config user.name "$GITHUB_ACTOR"
-        git config user.email "$GITHUB_ACTOR@users.noreply.github.com"    
-        
+        git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
     - name: Get Previous tag
       id: previoustag
       shell: bash
       run: |
-        git tag | sort -r --version-sort | head -n1 
-        echo "tag=$(git tag | sort -r --version-sort | head -n1)" >> "$GITHUB_OUTPUT" 
+        git tag | sort -r --version-sort | head -n1
+        echo "tag=$(git tag | sort -r --version-sort | head -n1)" >> "$GITHUB_OUTPUT"
       env:
         GITHUB_TOKEN: ${{ secrets.git-token }}
 
@@ -59,7 +58,7 @@ jobs:
       id: semvers
       uses: "WyriHaximus/github-action-next-semvers@v1"
       with:
-        version: ${{ inputs.override != ''  && inputs.override || steps.previousversion.outputs.version }} 
+        version: ${{ inputs.override != ''  && inputs.override || steps.previousversion.outputs.version }}
 
     - name: Set bumped version in output
       id: setversion
@@ -68,7 +67,6 @@ jobs:
         echo "patch=${{ steps.semvers.outputs.patch }}" >> "$GITHUB_OUTPUT"
         echo "minor=${{ steps.semvers.outputs.patch }}" | cut -d. -f1,2 >> "$GITHUB_OUTPUT"
         echo "major=${{ steps.semvers.outputs.patch }}" | cut -d. -f1 >> "$GITHUB_OUTPUT"
-        
 
     - name: Show the tags
       shell: bash
@@ -100,4 +98,3 @@ jobs:
       with:
         tag: v${{ steps.setversion.outputs.patch }}
         tag_exists_error: true
-

--- a/.github/workflows/internal-version.yaml
+++ b/.github/workflows/internal-version.yaml
@@ -27,7 +27,7 @@ on:
 jobs:
   increment-version:
     name: increment-version
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     outputs:
       version: ${{ steps.setversion.outputs.patch }}
       

--- a/.github/workflows/p2p-execute-command.yaml
+++ b/.github/workflows/p2p-execute-command.yaml
@@ -50,7 +50,6 @@ on:
         type: string
         default: '.'
 
-
 jobs:
   exec:
     name: '${{ inputs.command }} (${{ inputs.github_env }})'
@@ -87,10 +86,10 @@ jobs:
         if: ${{ inputs.optional == true }}
         working-directory: ${{ inputs.working-directory }}
         id: is_optional
-        run: |          
+        run: |
           declare -r optional_target=${{ inputs.command }}
           # match target in format: `.PHONY: <target_name>`, skip if commented out
-          if grep "^[^#]*.PHONY.*${optional_target}.*" ./Makefile; then            
+          if grep "^[^#]*.PHONY.*${optional_target}.*" ./Makefile; then
             echo "SKIP=false" >> $GITHUB_ENV
           else
             echo "WARNING: No Makefile target [$optional_target], skipping job"

--- a/.github/workflows/p2p-execute-command.yaml
+++ b/.github/workflows/p2p-execute-command.yaml
@@ -54,7 +54,7 @@ on:
 jobs:
   exec:
     name: '${{ inputs.command }} (${{ inputs.github_env }})'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     environment: ${{ inputs.github_env }}
     env:
       env_vars: ${{ secrets.env_vars }}

--- a/.github/workflows/p2p-execute-command.yaml
+++ b/.github/workflows/p2p-execute-command.yaml
@@ -146,7 +146,7 @@ jobs:
           done
 
       - name: Install iapc
-        uses: jaxxstorm/action-install-gh-release@v1.10.0
+        uses: jaxxstorm/action-install-gh-release@v1
         with:
           repo: cedws/iapc
           tag: v0.1.9

--- a/.github/workflows/p2p-get-latest-image-extended-test.yaml
+++ b/.github/workflows/p2p-get-latest-image-extended-test.yaml
@@ -1,4 +1,3 @@
-
 on:
   workflow_call:
     secrets:

--- a/.github/workflows/p2p-get-latest-image-prod.yaml
+++ b/.github/workflows/p2p-get-latest-image-prod.yaml
@@ -1,4 +1,3 @@
-
 on:
   workflow_call:
     secrets:

--- a/.github/workflows/p2p-get-latest-image.yaml
+++ b/.github/workflows/p2p-get-latest-image.yaml
@@ -37,7 +37,7 @@ on:
 jobs:
   get-latest-image:
     name: get-latest-image
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     outputs:
       version: ${{ steps.get-latest-image.outputs.version }}
     environment: ${{ fromJson(inputs.environment).include[0]['deploy_env'] }}

--- a/.github/workflows/p2p-get-latest-image.yaml
+++ b/.github/workflows/p2p-get-latest-image.yaml
@@ -33,7 +33,6 @@ on:
         required: true
         type: string
 
-
 jobs:
   get-latest-image:
     name: get-latest-image
@@ -84,6 +83,6 @@ jobs:
         working-directory: ${{ inputs.working-directory }}
         run: |
             [ $DRY_RUN == false ] && version=$(gcloud container images list-tags ${REGISTRY}/${REGISTRY_PATH}/${IMAGE_NAME} --limit=1 --format=json )
-            [  $? -gt 0 ] && [ $DRY_RUN == false ] && echo "exiting" && exit 1
+            [ $? -gt 0 ] && [ $DRY_RUN == false ] && echo "exiting" && exit 1
             [ $DRY_RUN == true ] && version="[{\"tags\": [\"0.0.0\"]}]"
             echo "version=$(echo ${version} | jq -r '.[0].tags[0]')" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/p2p-promote-image.yaml
+++ b/.github/workflows/p2p-promote-image.yaml
@@ -46,7 +46,6 @@ on:
         required: false
         type: string
 
-
 jobs:
   lookup:
     runs-on: ubuntu-24.04
@@ -99,7 +98,7 @@ jobs:
           yq -p=json -C <<EOT
           ${{ toJSON(env) }}
           EOT
-  
+
       - name: Checkout
         uses: actions/checkout@v4
         with:
@@ -142,7 +141,7 @@ jobs:
         uses: google-github-actions/setup-gcloud@v2
         with:
           install_components: beta,gke-gcloud-auth-plugin
-          
+
       - name: Setup kubeconfig
         id: setup-kubeconfig
         if: inputs.dry-run == false && inputs.connect-to-k8s == true
@@ -171,7 +170,7 @@ jobs:
           chmod +x corectl
           sudo mv corectl /usr/local/bin/
           rm corectl.tar.gz
-          
+
           corectl help
 
       - name: Decode environment variables
@@ -203,4 +202,3 @@ jobs:
           DEST_ACCESS_TOKEN: ${{ steps.auth-dest.outputs.access_token }}
         run: |
           make p2p-promote-to-${{ inputs.promotion-stage }}
-

--- a/.github/workflows/p2p-promote-image.yaml
+++ b/.github/workflows/p2p-promote-image.yaml
@@ -49,7 +49,7 @@ on:
 
 jobs:
   lookup:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     environment: ${{ fromJson(inputs.source_matrix).include[0]['deploy_env'] }}
     env:
       REGISTRY: ${{ inputs.region }}-docker.pkg.dev/${{ vars.PROJECT_ID }}/tenant/${{ vars.TENANT_NAME }}
@@ -68,7 +68,7 @@ jobs:
 
   promote-image:
     name: promote-to-${{ inputs.promotion-stage }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: [lookup]
     environment: ${{ inputs.dest_github_env }}
     env:

--- a/.github/workflows/p2p-version.yaml
+++ b/.github/workflows/p2p-version.yaml
@@ -34,7 +34,7 @@ on:
 jobs:
   increment-version:
     name: increment-version
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     outputs:
       version: ${{ steps.setversion.outputs.version }}
       previous_version: ${{ steps.setversion.outputs.previous_version }}

--- a/.github/workflows/p2p-version.yaml
+++ b/.github/workflows/p2p-version.yaml
@@ -30,7 +30,6 @@ on:
         type: string
         default: ''
 
-
 jobs:
   increment-version:
     name: increment-version
@@ -38,7 +37,7 @@ jobs:
     outputs:
       version: ${{ steps.setversion.outputs.version }}
       previous_version: ${{ steps.setversion.outputs.previous_version }}
-      
+
     steps:
     - uses: actions/checkout@v4
       with:
@@ -47,7 +46,7 @@ jobs:
     - name: Configure Git
       run: |
         git config user.name "$GITHUB_ACTOR"
-        git config user.email "$GITHUB_ACTOR@users.noreply.github.com"    
+        git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
     - name: Get Previous tag
       id: previoustag
@@ -59,8 +58,7 @@ jobs:
         REGEX=$(echo "^${VERSION_PREFIX}([0-9]+)\.([0-9]+)\.([0-9]+)$")
         PREVIOUS_VERSION=$(git tag | sort -r --version-sort | (grep -E ${REGEX} || echo "") | head -n1 )
         [ -z "$PREVIOUS_VERSION" ] && PREVIOUS_VERSION=${VERSION_PREFIX}0.0.0
-        echo "tag=$PREVIOUS_VERSION" >> "$GITHUB_OUTPUT" 
-      
+        echo "tag=$PREVIOUS_VERSION" >> "$GITHUB_OUTPUT"
 
     - name: get previous version from tag
       id: previousversion
@@ -74,7 +72,7 @@ jobs:
       id: semvers
       uses: "WyriHaximus/github-action-next-semvers@v1"
       with:
-        version: ${{ steps.previousversion.outputs.version }} 
+        version: ${{ steps.previousversion.outputs.version }}
 
     - name: get git hashes
       id: githashes
@@ -110,7 +108,7 @@ jobs:
 
         TAG=${{ steps.semvers.outputs.patch }}
         PREVIOUS_TAG=${{ steps.previousversion.outputs.version }}
- 
+
         HASH=${{ steps.githashes.outputs.current_hash }}
         LAST_TAG_HASH=${{ steps.githashes.outputs.previous_tag_hash }}
 

--- a/.github/workflows/p2p-workflow-extended-test.yaml
+++ b/.github/workflows/p2p-workflow-extended-test.yaml
@@ -1,4 +1,3 @@
-
 on:
   workflow_call:
     secrets:
@@ -41,7 +40,7 @@ on:
         type: string
 
 env:
-  REGION: ${{ inputs.region }} 
+  REGION: ${{ inputs.region }}
 
 jobs:
   run-tests:

--- a/.github/workflows/p2p-workflow-fastfeedback.yaml
+++ b/.github/workflows/p2p-workflow-fastfeedback.yaml
@@ -1,4 +1,3 @@
-
 on:
   workflow_call:
     secrets:
@@ -17,7 +16,7 @@ on:
         required: false
         type: string
         default: ''
-      version: 
+      version:
         required: true
         type: string
       region:
@@ -43,9 +42,8 @@ on:
       version:
         value: ${{ inputs.version }}
 
-
 env:
-  REGION: ${{ inputs.region }} 
+  REGION: ${{ inputs.region }}
 
 jobs:
   build:
@@ -132,5 +130,3 @@ jobs:
       working-directory: ${{ inputs.working-directory }}
       connect-to-k8s: true
       corectl-version: ${{ inputs.corectl-version }}
-
-

--- a/.github/workflows/p2p-workflow-prod.yaml
+++ b/.github/workflows/p2p-workflow-prod.yaml
@@ -1,4 +1,3 @@
-
 on:
   workflow_call:
     secrets:
@@ -30,7 +29,6 @@ on:
         type: string
         default: 'v'
 
-
 jobs:
   prod-deploy:
     name: prod-deploy
@@ -48,5 +46,3 @@ jobs:
       dry-run: ${{ inputs.dry-run }}
       working-directory: ${{ inputs.working-directory }}
       checkout-version: ${{ inputs.version-prefix }}${{ inputs.version }}
-
-


### PR DESCRIPTION
GitHub Actions will be transitioning ubuntu-default from 22.04 to 24.04 (https://github.com/actions/runner-images/issues/10636)

This will happen gradually in December and January.

We should proactively test and switch to avoid surprises.

See https://github.com/orgs/coreeng/projects/32/views/1?pane=issue&itemId=86555474&issue=coreeng%7Cproject-platform-accelerator%7C508

This PR changes the app workflows only, app workflows shall be tested and changed separately.
