### PR TITLE
Switch platform workflows from ubuntu-latest to ubuntu-24.04

### DIFF
--- a/.github/workflows/platform-cd.yaml
+++ b/.github/workflows/platform-cd.yaml
@@ -24,7 +24,7 @@ on:
 
 jobs:
   changes:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
       id-token: write
@@ -112,4 +112,3 @@ jobs:
       environment: ${{ inputs.environment }}
       platform: ${{ inputs.platform }}
       release: ${{ inputs.release }}
-      

--- a/.github/workflows/platform-ci.yaml
+++ b/.github/workflows/platform-ci.yaml
@@ -24,7 +24,7 @@ on:
 
 jobs:
   changes:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
       id-token: write
@@ -111,5 +111,3 @@ jobs:
       environment: ${{ inputs.environment }}
       platform: ${{ inputs.platform }}
       release: ${{ inputs.release }}
-      
-

--- a/.github/workflows/platform-environment-feature-matrix.yaml
+++ b/.github/workflows/platform-environment-feature-matrix.yaml
@@ -13,7 +13,7 @@ on:
 jobs:
   generate:
     name: generate
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     outputs:
       matrix: ${{ steps.generate-matrix.outputs.matrix }}
     steps:

--- a/.github/workflows/platform-environment-matrix.yaml
+++ b/.github/workflows/platform-environment-matrix.yaml
@@ -22,7 +22,7 @@ on:
 jobs:
   generate:
     name: generate
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     outputs:
       matrix: ${{ steps.generate-matrix.outputs.matrix }}
     steps:
@@ -34,7 +34,7 @@ jobs:
         name: Generate Matrix
         run: |
           # generate matrix
-          YAML_FILE=environments/environments.yaml 
+          YAML_FILE=environments/environments.yaml
           include_all="${{ inputs.include_all }}"
           environment="${{ inputs.environment }}"
           include_release="${{ inputs.include_release }}"
@@ -65,8 +65,8 @@ jobs:
                 allowed=true
               elif [ ! -e "${environment}" ] && echo "$env" | grep -wq "^${environment}$"; then
                 allowed=true
-              fi 
-              
+              fi
+
               if [ "${allowed}" == true ]; then
                 if [ "${include_release}" == true ]; then
                   e+="{\"environment\":\"$(yq .environment "${f}")\",\"platform\":\"$(yq .platform.vendor "${f}")\",\"release\":\"$(yq .release "${f}")\"},"

--- a/.github/workflows/platform-execute-command.yaml
+++ b/.github/workflows/platform-execute-command.yaml
@@ -32,7 +32,7 @@ on:
 jobs:
   developer-platform:
     name: ${{ inputs.feature }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     concurrency: ${{ inputs.environment }}-${{ github.ref }}
     environment: ${{ inputs.environment }}
 

--- a/.github/workflows/platform-release.yaml
+++ b/.github/workflows/platform-release.yaml
@@ -26,7 +26,7 @@ on:
 
 jobs:
   publish-pkg:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     if: github.ref_type == 'tag'
     permissions:
       contents: write
@@ -42,7 +42,7 @@ jobs:
           git push origin "pkg/${{ github.ref_name }}"
 
   generate:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     permissions:
       contents: read


### PR DESCRIPTION
GitHub Actions will be transitioning ubuntu-default from 22.04 to 24.04 (https://github.com/actions/runner-images/issues/10636)

This will happen gradually in December and January.

We should proactively test and switch to avoid surprises.

See https://github.com/orgs/coreeng/projects/32/views/1?pane=issue&itemId=86555474&issue=coreeng%7Cproject-platform-accelerator%7C508

This PR changes the platform workflows only, app workflows shall be tested and changed separately