### PR TITLE
Remove NumPy and Google SDK beta, only used for legacy IAP tunnel

### DIFF
--- a/.github/workflows/p2p-execute-command.yaml
+++ b/.github/workflows/p2p-execute-command.yaml
@@ -110,14 +110,7 @@ jobs:
         if: ${{ inputs.dry-run == false && env.SKIP == 'false' }}
         uses: google-github-actions/setup-gcloud@v2
         with:
-          install_components: beta,gke-gcloud-auth-plugin
-
-      - name: Setup NumPy
-        id: setup-numpy
-        if: ${{ inputs.dry-run == false && env.SKIP == 'false' }}
-        shell: bash
-        # https://cloud.google.com/iap/docs/using-tcp-forwarding#increasing_the_tcp_upload_bandwidth
-        run: $(gcloud info --format="value(basic.python_location)") -m pip install numpy
+          install_components: gke-gcloud-auth-plugin
 
       - name: Setup kubeconfig
         id: setup-kubeconfig

--- a/.github/workflows/p2p-promote-image.yaml
+++ b/.github/workflows/p2p-promote-image.yaml
@@ -128,19 +128,12 @@ jobs:
           token_format: access_token
           access_token_lifetime: 600s
 
-      - name: Setup NumPy
-        id: setup-numpy
-        if: inputs.dry-run == false && inputs.connect-to-k8s == true
-        shell: bash
-        # https://cloud.google.com/iap/docs/using-tcp-forwarding#increasing_the_tcp_upload_bandwidth
-        run: $(gcloud info --format="value(basic.python_location)") -m pip install numpy
-
       - name: Setup Google Cloud SDK
         id: setup-gcloud
         if: inputs.dry-run == false && inputs.connect-to-k8s == true
         uses: google-github-actions/setup-gcloud@v2
         with:
-          install_components: beta,gke-gcloud-auth-plugin
+          install_components: gke-gcloud-auth-plugin
 
       - name: Setup kubeconfig
         id: setup-kubeconfig


### PR DESCRIPTION
Removes NumPy and Google SDK beta stuff - these were required for the legacy IAP tunnel