### PR TITLE
Add Google Cloud SDK step back, but with skip_install

### DIFF
--- a/.github/workflows/p2p-execute-command.yaml
+++ b/.github/workflows/p2p-execute-command.yaml
@@ -112,6 +112,13 @@ jobs:
           token_format: access_token
           access_token_lifetime: 600s
 
+      - name: Setup Google Cloud SDK
+        id: setup-gcloud
+        if: ${{ inputs.dry-run == false && env.SKIP == 'false' }}
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          skip_install: true
+
       - name: Setup kubeconfig
         id: setup-kubeconfig
         if: ${{ inputs.dry-run == false && env.SKIP == 'false' }}

--- a/.github/workflows/p2p-promote-image.yaml
+++ b/.github/workflows/p2p-promote-image.yaml
@@ -133,6 +133,13 @@ jobs:
           token_format: access_token
           access_token_lifetime: 600s
 
+      - name: Setup Google Cloud SDK
+        id: setup-gcloud
+        if: inputs.dry-run == false && inputs.connect-to-k8s == true
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          skip_install: true
+
       - name: Setup kubeconfig
         id: setup-kubeconfig
         if: inputs.dry-run == false && inputs.connect-to-k8s == true


### PR DESCRIPTION
Adds back the steps to setup google cloud sdk that were removed by https://github.com/coreeng/p2p/pull/78 but with skip_install set to true.