### PR TITLE
P2P V2 Test

### DIFF
--- a/.github/workflows/p2p-execute-command.yaml
+++ b/.github/workflows/p2p-execute-command.yaml
@@ -25,6 +25,14 @@ on:
         required: false
         type: string
         default: europe-west2
+      subnamespace:
+        required: false
+        type: string
+        default: ''
+      app-name:
+        required: false
+        type: string
+        default: ''
       version:
         required: true
         type: string
@@ -35,10 +43,6 @@ on:
         required: false
         type: string
         default: europe-west2-a
-      optional:
-        required: false
-        type: boolean
-        default: false
       pre-targets:
         description: |
           Make targets to run before the command
@@ -60,6 +64,7 @@ jobs:
   exec:
     name: '${{ inputs.command }} (${{ inputs.github_env }})'
     runs-on: ubuntu-24.04
+    concurrency: ${{ inputs.github_env }}/${{ vars.TENANT_NAME }}-${{ inputs.app-name }}-${{ inputs.subnamespace }}
     environment: ${{ inputs.github_env }}
     env:
       env_vars: ${{ secrets.env_vars }}
@@ -75,7 +80,6 @@ jobs:
       SERVICE_ACCOUNT: p2p-${{ vars.TENANT_NAME }}@${{ vars.PROJECT_ID }}.iam.gserviceaccount.com
       TENANT_NAME: ${{ vars.TENANT_NAME }}
       WORKLOAD_IDENTITY_PROVIDER: projects/${{ vars.PROJECT_NUMBER }}/locations/global/workloadIdentityPools/p2p-${{ vars.TENANT_NAME }}/providers/p2p-${{ vars.TENANT_NAME }}
-      SKIP: ${{ inputs.optional }}
     steps:
       - name: print env context
         run: |
@@ -88,22 +92,9 @@ jobs:
         with:
           ref: ${{ inputs.dry-run == false && inputs.checkout-version || '' }}
 
-      - name: Skip job when optional and make target not exist
-        if: ${{ inputs.optional == true }}
-        working-directory: ${{ inputs.working-directory }}
-        id: is_optional
-        run: |
-          declare -r optional_target=${{ inputs.command }}
-          # match target in format: `.PHONY: <target_name>`, skip if commented out
-          if grep "^[^#]*.PHONY.*${optional_target}.*" ./Makefile; then
-            echo "SKIP=false" >> $GITHUB_ENV
-          else
-            echo "WARNING: No Makefile target [$optional_target], skipping job"
-          fi
-
       - name: Authenticate to Google Cloud
         id: auth
-        if: ${{ inputs.dry-run == false && env.SKIP == 'false' }}
+        if: ${{ inputs.dry-run == false }}
         uses: google-github-actions/auth@v2
         with:
           workload_identity_provider: ${{ env.WORKLOAD_IDENTITY_PROVIDER }}
@@ -114,14 +105,14 @@ jobs:
 
       - name: Setup Google Cloud SDK
         id: setup-gcloud
-        if: ${{ inputs.dry-run == false && env.SKIP == 'false' }}
+        if: ${{ inputs.dry-run == false }}
         uses: google-github-actions/setup-gcloud@v2
         with:
           skip_install: true
 
       - name: Setup kubeconfig
         id: setup-kubeconfig
-        if: ${{ inputs.dry-run == false && env.SKIP == 'false' }}
+        if: ${{ inputs.dry-run == false }}
         uses: google-github-actions/get-gke-credentials@v2
         with:
           context_name: gke_${{ env.PROJECT_ID }}_${{ inputs.region }}_${{ env.DPLATFORM }}
@@ -132,39 +123,99 @@ jobs:
 
       - name: Test kubeconfig
         id: test-kubeconfig
-        if: ${{ inputs.dry-run == false && env.SKIP == 'false' }}
+        if: ${{ inputs.dry-run == false }}
         run: |
           kubectl cluster-info
 
+      - name: Setup Docker Buildx
+        id: setup-docker-buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          driver-opts: |
+            default-load=true
+
+      - name: Expose GitHub Runtime
+        id: expose-github-runtime
+        uses: crazy-max/ghaction-github-runtime@v3
+
       - name: Login to Artifact Registry
         uses: docker/login-action@v3
-        if: ${{ inputs.dry-run == false && env.SKIP == 'false' }}
+        if: ${{ inputs.dry-run == false }}
         with:
           registry: europe-west2-docker.pkg.dev
           username: oauth2accesstoken
           password: ${{ steps.auth.outputs.access_token }}
-
-      - name: Decode environment variables
-        if:  ${{ env.SKIP == 'false' }}
-        run: |
-          for i in $env_vars; do
-            i=$(echo $i | sed 's/=.*//g')=$(echo ${i#*=})
-            echo ::add-mask::${i#*=}
-            printf '%s\n' $i >> $GITHUB_ENV
-          done
 
       - name: Login to tenant provided registry
         env:
           REGISTRY_USER: ${{ secrets.container_registry_user }}
           REGISTRY_PAT: ${{ secrets.container_registry_pat }}
           REGISTRY_URL: ${{ secrets.container_registry_url }}
-        if:  ${{ env.SKIP == 'false' && env.REGISTRY_USER && env.REGISTRY_PAT }}
+        if:  ${{ env.REGISTRY_USER && env.REGISTRY_PAT }}
         run: |
           echo ${{ env.REGISTRY_PAT }} | docker login ${{ env.REGISTRY_URL }} -u ${{ env.REGISTRY_USER }} --password-stdin
 
-      - name: Run Command
+      - name: ${{ inputs.subnamespace == '' && 'Setup subnamespace' || format('Setup subnamespace {0}', inputs.app-name != vars.TENANT_NAME && format('{0}-{1}-{2}', vars.TENANT_NAME, inputs.app-name, inputs.subnamespace) || format('{0}-{1}', vars.TENANT_NAME, inputs.subnamespace)) }}
+        id: setup-subnamespace
+        if: ${{ inputs.dry-run == false && inputs.app-name != '' && inputs.subnamespace != '' }}
+        run: |
+          if [[ "${{ vars.TENANT_NAME }}" == "${{ inputs.app-name }}" ]]; then
+            SUBNAMESPACE="${{ vars.TENANT_NAME }}-${{ inputs.subnamespace }}"
+          else
+            SUBNAMESPACE="${{ vars.TENANT_NAME }}-${{ inputs.app-name }}-${{ inputs.subnamespace }}"
+          fi
+          set -euo pipefail
+          cat <<EOF | kubectl apply -n "${{ vars.TENANT_NAME }}" -f -
+          apiVersion: hnc.x-k8s.io/v1alpha2
+          kind: SubnamespaceAnchor
+          metadata:
+            name: ${SUBNAMESPACE}
+          EOF
+          until [ "$(kubectl -n "${{ vars.TENANT_NAME }}" get subnamespaceanchor "${SUBNAMESPACE}" -o jsonpath='{.status.status}' 2>/dev/null)" = "Ok" ]; do
+            echo "Waiting for subnamespace ${SUBNAMESPACE} to be ready..."
+            sleep 2
+          done
+          kubectl config set-context --current --namespace="${SUBNAMESPACE}"
+          echo ""
+          kubectl get ns "${SUBNAMESPACE}"
+
+      - name: Decode environment variables
+        run: |
+          for i in $env_vars; do
+            i=$(echo $i | sed 's/=.*//g')=$(echo ${i#*=})
+            echo ::add-mask::${i#*=}
+            printf '%s\n' $i >> "${GITHUB_ENV}"
+          done
+
+      - name: Set p2p variables
+        id: setup-p2p-variables
+        run: |
+          env | grep "^P2P_" | sort
+          export P2P_TENANT_NAME=${{ vars.TENANT_NAME }}
+          export P2P_APP_NAME=${{ inputs.app-name }}
+          export P2P_VERSION=${{ inputs.version }}
+          export P2P_REGISTRY=${{ inputs.region }}-docker.pkg.dev/${{ vars.PROJECT_ID }}/tenant/${{ vars.TENANT_NAME }}
+          export P2P_REGISTRY_FAST_FEEDBACK_PATH=fast-feedback
+          export P2P_REGISTRY_EXTENDED_TEST_PATH=extended-test
+          export P2P_REGISTRY_PROD_PATH=prod
+          export P2P_REGISTRY_FAST_FEEDBACK=${P2P_REGISTRY}/${P2P_REGISTRY_FAST_FEEDBACK_PATH}
+          export P2P_REGISTRY_EXTENDED_TEST=${P2P_REGISTRY}/${P2P_REGISTRY_EXTENDED_TEST_PATH}
+          export P2P_REGISTRY_PROD=${P2P_REGISTRY}/${P2P_REGISTRY_PROD_PATH}
+          if [[ "${{ vars.TENANT_NAME }}" == "${{ inputs.app-name }}" ]]; then
+            P2P_NAMESPACE="${{ vars.TENANT_NAME }}"
+          else
+            P2P_NAMESPACE="${{ vars.TENANT_NAME }}-${{ inputs.app-name }}"
+          fi
+          export P2P_NAMESPACE_FUNCTIONAL=${P2P_NAMESPACE}-functional
+          export P2P_NAMESPACE_NFT=${P2P_NAMESPACE}-nft
+          export P2P_NAMESPACE_INTEGRATION=${P2P_NAMESPACE}-integration
+          export P2P_NAMESPACE_EXTENDED=${P2P_NAMESPACE}-extended
+          export P2P_NAMESPACE_PROD=${P2P_NAMESPACE}-prod
+          env | grep "^P2P_" | sort | tee "${GITHUB_ENV}"
+
+      - name: Run make ${{ inputs.command }}
         id: run-command
-        if: ${{ inputs.dry-run == false && env.SKIP == 'false' }}
+        if: ${{ inputs.dry-run == false }}
         working-directory: ${{ inputs.working-directory }}
         env:
           GOOGLE_APPLICATION_CREDENTIALS: ${{ steps.auth.outputs.credentials_file_path }}

--- a/.github/workflows/p2p-promote-image.yaml
+++ b/.github/workflows/p2p-promote-image.yaml
@@ -23,6 +23,10 @@ on:
       dest_github_env:
         required: true
         type: string
+      app-name:
+        required: false
+        type: string
+        default: ''
       version:
         required: false
         type: string
@@ -165,32 +169,53 @@ jobs:
         env:
           CORECTL_VERSION: ${{ inputs.corectl-version }}
         run: |
-          if [ -z "$CORECTL_VERSION" ]; then
-          echo "No version specified, finding latest release"
+          if [ -z "${CORECTL_VERSION}" ]; then
             CORECTL_VERSION=$(curl -s https://api.github.com/repos/coreeng/corectl/releases/latest | grep '"tag_name":' | cut -d'"' -f4)
           fi
-          echo "Downloading version $CORECTL_VERSION"
-          RELEASE_URL="https://github.com/coreeng/corectl/releases/download/${CORECTL_VERSION}/corectl_Linux_x86_64.tar.gz"
-
-          curl -L $RELEASE_URL -o corectl.tar.gz
-          tar -xzf corectl.tar.gz
-          chmod +x corectl
-          sudo mv corectl /usr/local/bin/
-          rm corectl.tar.gz
-
-          corectl help
+          echo "Downloading corectl ${CORECTL_VERSION}..."
+          curl -Lso corectl.tgz "https://github.com/coreeng/corectl/releases/download/${CORECTL_VERSION}/corectl_Linux_x86_64.tar.gz"
+          tar zxf corectl.tgz
+          sudo install -o root -g root -m 0755 corectl /usr/local/bin/
+          rm corectl.tgz corectl
+          corectl version
 
       - name: Decode environment variables
         run: |
           for i in $env_vars; do
             i=$(echo $i | sed 's/=.*//g')=$(echo ${i#*=})
             echo ::add-mask::${i#*=}
-            printf '%s\n' $i >> $GITHUB_ENV
+            printf '%s\n' $i >> "${GITHUB_ENV}"
           done
 
-      - name: Promote
+      - name: Set p2p variables
+        id: setup-p2p-variables
+        run: |
+          env | grep "^P2P_" | sort
+          export P2P_TENANT_NAME=${{ vars.TENANT_NAME }}
+          export P2P_APP_NAME=${{ inputs.app-name }}
+          export P2P_VERSION=${{ inputs.version }}
+          export P2P_REGISTRY=${{ inputs.region }}-docker.pkg.dev/${{ vars.PROJECT_ID }}/tenant/${{ vars.TENANT_NAME }}
+          export P2P_REGISTRY_FAST_FEEDBACK_PATH=fast-feedback
+          export P2P_REGISTRY_EXTENDED_TEST_PATH=extended-test
+          export P2P_REGISTRY_PROD_PATH=prod
+          export P2P_REGISTRY_FAST_FEEDBACK=${P2P_REGISTRY}/${P2P_REGISTRY_FAST_FEEDBACK_PATH}
+          export P2P_REGISTRY_EXTENDED_TEST=${P2P_REGISTRY}/${P2P_REGISTRY_EXTENDED_TEST_PATH}
+          export P2P_REGISTRY_PROD=${P2P_REGISTRY}/${P2P_REGISTRY_PROD_PATH}
+          if [[ "${{ vars.TENANT_NAME }}" == "${{ inputs.app-name }}" ]]; then
+            P2P_NAMESPACE="${{ vars.TENANT_NAME }}"
+          else
+            P2P_NAMESPACE="${{ vars.TENANT_NAME }}-${{ inputs.app-name }}"
+          fi
+          export P2P_NAMESPACE_FUNCTIONAL=${P2P_NAMESPACE}-functional
+          export P2P_NAMESPACE_NFT=${P2P_NAMESPACE}-nft
+          export P2P_NAMESPACE_INTEGRATION=${P2P_NAMESPACE}-integration
+          export P2P_NAMESPACE_EXTENDED=${P2P_NAMESPACE}-extended
+          export P2P_NAMESPACE_PROD=${P2P_NAMESPACE}-prod
+          env | grep "^P2P_" | sort | tee "${GITHUB_ENV}"
+
+      - name: Promote to ${{ inputs.promotion-stage }}
         id: run-promotion
-        if: inputs.dry-run == false
+        if: ${{ inputs.dry-run == false }}
         working-directory: ${{ inputs.working-directory }}
         env:
           SOURCE_AUTH_OVERRIDE: ${{ steps.auth-source.outputs.credentials_file_path }}

--- a/.github/workflows/p2p-workflow-extended-test.yaml
+++ b/.github/workflows/p2p-workflow-extended-test.yaml
@@ -34,6 +34,10 @@ on:
         required: false
         type: string
         default: '.'
+      app-name:
+        required: false
+        type: string
+        default: ''
       version:
         required: true
         type: string
@@ -59,7 +63,9 @@ jobs:
       fail-fast: false
     with:
       command: p2p-extended-test
+      subnamespace: extended
       github_env: ${{ matrix.deploy_env }}
+      app-name: ${{ inputs.app-name }}
       version: ${{ inputs.version }}
       dry-run: ${{ inputs.dry-run }}
       working-directory: ${{ inputs.working-directory }}
@@ -78,6 +84,7 @@ jobs:
       source_matrix: ${{ inputs.source }}
       dest_github_env: ${{ matrix.deploy_env }}
       promotion-stage: prod
+      app-name: ${{ inputs.app-name }}
       version: ${{ inputs.version  }}
       dry-run: ${{ inputs.dry-run }}
       working-directory: ${{ inputs.working-directory }}

--- a/.github/workflows/p2p-workflow-fastfeedback.yaml
+++ b/.github/workflows/p2p-workflow-fastfeedback.yaml
@@ -22,6 +22,10 @@ on:
         required: false
         type: string
         default: ''
+      app-name:
+        required: false
+        type: string
+        default: ''
       version:
         required: true
         type: string
@@ -62,6 +66,7 @@ jobs:
     with:
       command: p2p-build
       github_env: ${{ matrix.deploy_env }}
+      app-name: ${{ inputs.app-name }}
       version: ${{ inputs.version }}
       checkout-version: ${{ inputs.checkout-version }}
       dry-run: ${{ inputs.dry-run }}
@@ -81,8 +86,10 @@ jobs:
       fail-fast: false
     with:
       command: p2p-functional
+      subnamespace: functional
       region: ${{ inputs.region }}
       github_env: ${{ matrix.deploy_env }}
+      app-name: ${{ inputs.app-name }}
       version: ${{ inputs.version }}
       checkout-version: ${{ inputs.checkout-version }}
       dry-run: ${{ inputs.dry-run }}
@@ -101,8 +108,10 @@ jobs:
       fail-fast: false
     with:
       command: p2p-nft
+      subnamespace: nft
       region: ${{ inputs.region }}
       github_env: ${{ matrix.deploy_env }}
+      app-name: ${{ inputs.app-name }}
       version: ${{ inputs.version }}
       checkout-version: ${{ inputs.checkout-version }}
       dry-run: ${{ inputs.dry-run }}
@@ -121,9 +130,10 @@ jobs:
       fail-fast: false
     with:
       command: p2p-integration
-      optional: true
+      subnamespace: integration
       region: ${{ inputs.region }}
       github_env: ${{ matrix.deploy_env }}
+      app-name: ${{ inputs.app-name }}
       version: ${{ inputs.version }}
       checkout-version: ${{ inputs.checkout-version }}
       dry-run: ${{ inputs.dry-run }}
@@ -144,6 +154,7 @@ jobs:
       dest_github_env: ${{ matrix.deploy_env }}
       region: ${{ inputs.region }}
       promotion-stage: extended-test
+      app-name: ${{ inputs.app-name }}
       version: ${{ inputs.version }}
       checkout-version: ${{ inputs.checkout-version }}
       dry-run: ${{ inputs.dry-run }}

--- a/.github/workflows/p2p-workflow-prod.yaml
+++ b/.github/workflows/p2p-workflow-prod.yaml
@@ -30,6 +30,10 @@ on:
         required: false
         type: string
         default: europe-west2
+      app-name:
+        required: false
+        type: string
+        default: ''
       version:
         required: false
         type: string
@@ -54,8 +58,10 @@ jobs:
       fail-fast: false
     with:
       command: p2p-prod
+      subnamespace: prod
       region: ${{ inputs.region }}
       github_env: ${{ matrix.deploy_env }}
+      app-name: ${{ inputs.app-name }}
       version: ${{ inputs.version }}
       dry-run: ${{ inputs.dry-run }}
       working-directory: ${{ inputs.working-directory }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+*.swp
 .idea/
 .history/
 .vscode/

--- a/p2p.mk
+++ b/p2p.mk
@@ -1,0 +1,92 @@
+MAKEFLAGS += --warn-undefined-variables
+
+# Set p2p variables for local testing
+P2P_TENANT_NAME ?= default-tenant
+P2P_APP_NAME ?= default-app
+P2P_VERSION ?= $(shell git rev-parse --short HEAD)
+P2P_REGISTRY ?= localhost/local
+P2P_REGISTRY_FAST_FEEDBACK_PATH ?= fast-feedback
+P2P_REGISTRY_EXTENDED_TEST_PATH ?= extended-test
+P2P_REGISTRY_PROD_PATH ?= prod
+P2P_REGISTRY_FAST_FEEDBACK ?= $(P2P_REGISTRY)/$(P2P_REGISTRY_FAST_FEEDBACK_PATH)
+P2P_REGISTRY_EXTENDED_TEST ?= $(P2P_REGISTRY)/$(P2P_REGISTRY_EXTENDED_TEST_PATH)
+P2P_REGISTRY_PROD ?= $(P2P_REGISTRY)/$(P2P_REGISTRY_PROD_PATH)
+P2P_NAMESPACE ?= $(P2P_APP_NAME)
+P2P_NAMESPACE_FUNCTIONAL ?= $(P2P_NAMESPACE)-functional
+P2P_NAMESPACE_NFT ?= $(P2P_NAMESPACE)-nft
+P2P_NAMESPACE_INTEGRATION ?= $(P2P_NAMESPACE)-integration
+P2P_NAMESPACE_EXTENDED ?= $(P2P_NAMESPACE)-extended
+P2P_NAMESPACE_PROD ?= $(P2P_NAMESPACE)-prod
+
+P2P_IMAGE_NAMES ?= $(P2P_APP_NAME)
+
+.PHONY: p2p-help
+p2p-help:
+	@echo "Usage:"
+	@grep -E '^[a-zA-Z1-9_-]+:.*?## .*$$' -h $(MAKEFILE_LIST) | grep '^p2p-' | awk 'BEGIN {FS = ":.*?## "}; {printf "  make %-30s %s\n", $$1, $$2}'
+
+%: p2p_tenant_name = $(P2P_TENANT_NAME)
+%: p2p_app_name = $(P2P_APP_NAME)
+%: p2p_version = $(P2P_VERSION)
+
+.PHONY: p2p-build
+p2p-build: lint build-app ## Build the app
+%-app: p2p_registry=$(P2P_REGISTRY_FAST_FEEDBACK)
+%-app: p2p_image_tag=$(P2P_REGISTRY_FAST_FEEDBACK)/$(if $(filter-out undefined,$(origin 1)),$(1),$(P2P_APP_NAME)):$(P2P_VERSION)
+%-app: p2p_image_cache=--cache-from=type=gha,scope=$(if $(filter-out undefined,$(origin 1)),$(1),$(P2P_APP_NAME)) --cache-to=type=gha,scope=$(if $(filter-out undefined,$(origin 1)),$(1),$(P2P_APP_NAME)),mode=max
+
+.PHONY: p2p-functional
+p2p-functional: build-functional deploy-functional test-functional ## Run functional tests
+%-functional: p2p_app_url_suffix=-$(P2P_TENANT_NAME)-functional
+%-functional: p2p_namespace=$(P2P_NAMESPACE_FUNCTIONAL)
+%-functional: p2p_registry=$(P2P_REGISTRY_FAST_FEEDBACK)
+%-functional: p2p_image_tag=$(P2P_REGISTRY_FAST_FEEDBACK)/$(if $(filter-out undefined,$(origin 1)),$(1),$(P2P_APP_NAME))-functional:$(P2P_VERSION)
+%-functional: p2p_image_cache=--cache-from=type=gha,scope=$(if $(filter-out undefined,$(origin 1)),$(1),$(P2P_APP_NAME))-functional --cache-to=type=gha,scope=$(if $(filter-out undefined,$(origin 1)),$(1),$(P2P_APP_NAME))-functional,mode=max
+
+.PHONY: p2p-nft
+p2p-nft: build-nft deploy-nft test-nft ## Run NFT tests
+%-nft: p2p_app_url_suffix=-$(P2P_TENANT_NAME)-nft
+%-nft: p2p_namespace=$(P2P_NAMESPACE_NFT)
+%-nft: p2p_registry=$(P2P_REGISTRY_FAST_FEEDBACK)
+%-nft: p2p_image_tag=$(P2P_REGISTRY_FAST_FEEDBACK)/$(if $(filter-out undefined,$(origin 1)),$(1),$(P2P_APP_NAME))-nft:$(P2P_VERSION)
+%-nft: p2p_image_cache=--cache-from=type=gha,scope=$(if $(filter-out undefined,$(origin 1)),$(1),$(P2P_APP_NAME))-nft --cache-to=type=gha,scope=$(if $(filter-out undefined,$(origin 1)),$(1),$(P2P_APP_NAME))-nft,mode=max
+
+.PHONY: p2p-integration
+p2p-integration: build-integration deploy-integration test-integration ## Run integration tests
+%-integration: p2p_app_url_suffix=-$(P2P_TENANT_NAME)-integration
+%-integration: p2p_namespace=$(P2P_NAMESPACE_INTEGRATION)
+%-integration: p2p_registry=$(P2P_REGISTRY_FAST_FEEDBACK)
+%-integration: p2p_image_tag=$(P2P_REGISTRY_FAST_FEEDBACK)/$(if $(filter-out undefined,$(origin 1)),$(1),$(P2P_APP_NAME))-integration:$(P2P_VERSION)
+%-integration: p2p_image_cache=--cache-from=type=gha,scope=$(if $(filter-out undefined,$(origin 1)),$(1),$(P2P_APP_NAME))-integration --cache-to=type=gha,scope=$(if $(filter-out undefined,$(origin 1)),$(1),$(P2P_APP_NAME))-integration,mode=max
+
+.PHONY: p2p-promote-to-extended-test
+p2p-promote-to-extended-test: ## Promote to extended test
+	$(foreach image, $(P2P_IMAGE_NAMES), \
+		corectl p2p promote "$(image):$(P2P_VERSION)" \
+			--source-stage "$(P2P_REGISTRY_FAST_FEEDBACK_PATH)" \
+			--dest-registry "$(P2P_REGISTRY)" \
+			--dest-stage "$(P2P_REGISTRY_EXTENDED_TEST_PATH)" \
+	;)
+
+.PHONY: p2p-extended-test
+p2p-extended-test: build-extended-test deploy-extended-test test-extended-test ## Run extended tests
+%-extended-test: p2p_app_url_suffix=-$(P2P_TENANT_NAME)-extended
+%-extended-test: p2p_namespace=$(P2P_NAMESPACE_EXTENDED)
+%-extended-test: p2p_registry=$(P2P_REGISTRY_EXTENDED_TEST)
+%-extended-test: p2p_image_tag=$(P2P_REGISTRY_EXTENDED_TEST)/$(if $(filter-out undefined,$(origin 1)),$(1),$(P2P_APP_NAME))-extended:$(P2P_VERSION)
+%-extended-test: p2p_image_cache=--cache-from=type=gha,scope=$(if $(filter-out undefined,$(origin 1)),$(1),$(P2P_APP_NAME))-extended --cache-to=type=gha,scope=$(if $(filter-out undefined,$(origin 1)),$(1),$(P2P_APP_NAME))-extended,mode=max
+
+.PHONY: p2p-promote-to-prod
+p2p-promote-to-prod: ## Promote to prod
+	$(foreach image, $(P2P_IMAGE_NAMES), \
+		corectl p2p promote "$(image):$(P2P_VERSION)" \
+			--source-stage "$(P2P_REGISTRY_EXTENDED_TEST_PATH)" \
+			--dest-registry "$(P2P_REGISTRY)" \
+			--dest-stage "$(P2P_REGISTRY_PROD_PATH)" \
+	;)
+
+.PHONY: p2p-prod
+p2p-prod: deploy-prod ## Deploy to prod
+%-prod: p2p_app_url_suffix=
+%-prod: p2p_namespace=$(P2P_NAMESPACE_PROD)
+%-prod: p2p_registry=$(P2P_REGISTRY_PROD)


### PR DESCRIPTION
Adds P2P V2 functionality in a backwards compatible way, for testing.

- Introduces `app-name` - when set, p2p will automatically create subnamespaces on demand
- Introduces `P2P_*` env variables when calling Makefile (including namespaces) to be used by the Makefile
- Introduces `p2p.mk` - a Makefile to be included by apps that uses the `P2P_*` variables and implements the interface with actions
- Concurrency of executing make commands limited per env, tenant, app-name, & subnamespace

The intention is to make `app-name` required, which would be a breaking change, once all CECG apps have migrated to this setup.

Updated software templates test: https://github.com/coreeng/p2p-v2-test

Relevant issue: https://github.com/coreeng/project-core-platform/issues/574
