### PR TITLE
P2P_VERSION should default to something that's semver

### DIFF
--- a/p2p.mk
+++ b/p2p.mk
@@ -3,7 +3,7 @@ MAKEFLAGS += --warn-undefined-variables
 # Set p2p variables for local testing
 P2P_TENANT_NAME ?= default-tenant
 P2P_APP_NAME ?= default-app
-P2P_VERSION ?= $(shell git rev-parse --short HEAD)
+P2P_VERSION ?= 0.0.0-$(shell git rev-parse --short HEAD)
 P2P_REGISTRY ?= localhost/local
 P2P_REGISTRY_FAST_FEEDBACK_PATH ?= fast-feedback
 P2P_REGISTRY_EXTENDED_TEST_PATH ?= extended-test


### PR DESCRIPTION
The fallback for local builds was just using the short git ref, this prepends 0.0.0- to it so it's semver compatible as tools downstream might expect this to be semver.