### PR TITLE
Fix env_vars whitespace handling backslash handling

### DIFF
--- a/.github/workflows/p2p-execute-command.yaml
+++ b/.github/workflows/p2p-execute-command.yaml
@@ -185,9 +185,9 @@ jobs:
         run: |
           IFS=$'\n'
           for i in $env_vars; do
-            i=$(echo "$i" | sed 's/=.*//g')="${i#*=}"
+            i="${i%%=*}"="${i#*=}"
             echo "::add-mask::${i#*=}"
-            printf '%s\n' "$i" >> "${GITHUB_ENV}"
+            printf '%s\n' "${i//\\/\\\\}" >> "${GITHUB_ENV}"
           done
 
       - name: Set p2p variables

--- a/.github/workflows/platform-execute-command.yaml
+++ b/.github/workflows/platform-execute-command.yaml
@@ -110,9 +110,9 @@ jobs:
         run: |
           IFS=$'\n'
           for i in $env_vars; do
-            i=$(echo "$i" | sed 's/=.*//g')="${i#*=}"
+            i="${i%%=*}"="${i#*=}"
             echo "::add-mask::${i#*=}"
-            printf '%s\n' "$i" >> "${GITHUB_ENV}"
+            printf '%s\n' "${i//\\/\\\\}" >> "${GITHUB_ENV}"
           done
 
       - id: make-targets


### PR DESCRIPTION
Escape backslashes before outputing them to $GITHUB_ENV