### PR TITLE
Fix env_vars handling in promote image workflow

### DIFF
--- a/.github/workflows/p2p-execute-command.yaml
+++ b/.github/workflows/p2p-execute-command.yaml
@@ -182,6 +182,7 @@ jobs:
           kubectl get ns "${SUBNAMESPACE}"
 
       - name: Decode environment variables
+        shell: bash
         run: |
           IFS=$'\n'
           for i in $env_vars; do

--- a/.github/workflows/p2p-promote-image.yaml
+++ b/.github/workflows/p2p-promote-image.yaml
@@ -180,11 +180,13 @@ jobs:
           corectl version
 
       - name: Decode environment variables
+        shell: bash
         run: |
+          IFS=$'\n'
           for i in $env_vars; do
-            i=$(echo $i | sed 's/=.*//g')=$(echo ${i#*=})
-            echo ::add-mask::${i#*=}
-            printf '%s\n' $i >> "${GITHUB_ENV}"
+            i="${i%%=*}"="${i#*=}"
+            echo "::add-mask::${i#*=}"
+            printf '%s\n' "${i//\\/\\\\}" >> "${GITHUB_ENV}"
           done
 
       - name: Set p2p variables

--- a/.github/workflows/platform-execute-command.yaml
+++ b/.github/workflows/platform-execute-command.yaml
@@ -107,6 +107,7 @@ jobs:
           mv "${GITHUB_WORKSPACE}/tenants" "/app/tenants"
 
       - name: Decode environment variables
+        shell: bash
         run: |
           IFS=$'\n'
           for i in $env_vars; do


### PR DESCRIPTION
Also explicitly set shell to bash as this substitution wouldn't work if the shell isn't bash.