### PR TITLE
Use skopeo to promote oci images, remove corectl

### DIFF
--- a/.github/workflows/p2p-promote-image.yaml
+++ b/.github/workflows/p2p-promote-image.yaml
@@ -38,9 +38,6 @@ on:
       checkout-version:
         required: false
         type: string
-      corectl-version:
-        required: false
-        type: string
 
 jobs:
   lookup:
@@ -129,22 +126,6 @@ jobs:
           token_format: access_token
           access_token_lifetime: 3600s
 
-      - name: Setup corectl
-        id: setup-corectl
-        if: inputs.dry-run == false
-        env:
-          CORECTL_VERSION: ${{ inputs.corectl-version }}
-        run: |
-          if [ -z "${CORECTL_VERSION}" ]; then
-            CORECTL_VERSION=$(curl -s https://api.github.com/repos/coreeng/corectl/releases/latest | grep '"tag_name":' | cut -d'"' -f4)
-          fi
-          echo "Downloading corectl ${CORECTL_VERSION}..."
-          curl -Lso corectl.tgz "https://github.com/coreeng/corectl/releases/download/${CORECTL_VERSION}/corectl_Linux_x86_64.tar.gz"
-          tar zxf corectl.tgz
-          sudo install -o root -g root -m 0755 corectl /usr/local/bin/
-          rm corectl.tgz corectl
-          corectl version
-
       - name: Decode environment variables
         shell: bash
         run: |
@@ -180,6 +161,16 @@ jobs:
           export P2P_NAMESPACE_EXTENDED=${P2P_NAMESPACE}-extended
           export P2P_NAMESPACE_PROD=${P2P_NAMESPACE}-prod
           env | grep "^P2P_" | sort | tee "${GITHUB_ENV}"
+
+      - name: Setup skopeo
+        id: setup-skopeo
+        if: ${{ inputs.dry-run == false }}
+        env:
+          SOURCE_ACCESS_TOKEN: ${{ steps.auth-source.outputs.access_token }}
+          DEST_ACCESS_TOKEN: ${{ steps.auth-dest.outputs.access_token }}
+        run: |
+          skopeo login -u oauth2accesstoken --password-stdin "${SOURCE_REGISTRY}" < <(echo "${SOURCE_ACCESS_TOKEN}")
+          skopeo login -u oauth2accesstoken --password-stdin "${REGISTRY}" < <(echo "${DEST_ACCESS_TOKEN}")
 
       - name: Promote to ${{ inputs.promotion-stage }}
         id: run-promotion

--- a/.github/workflows/p2p-workflow-extended-test.yaml
+++ b/.github/workflows/p2p-workflow-extended-test.yaml
@@ -45,9 +45,6 @@ on:
         required: false
         type: string
         default: 'v'
-      corectl-version:
-        required: false
-        type: string
 
 jobs:
   run-tests:
@@ -91,4 +88,3 @@ jobs:
       dry-run: ${{ inputs.dry-run }}
       working-directory: ${{ inputs.working-directory }}
       checkout-version: ${{ inputs.version-prefix }}${{ inputs.version }}
-      corectl-version: ${{ inputs.corectl-version }}

--- a/.github/workflows/p2p-workflow-fastfeedback.yaml
+++ b/.github/workflows/p2p-workflow-fastfeedback.yaml
@@ -45,9 +45,6 @@ on:
         required: false
         type: string
         default: '.'
-      corectl-version:
-        required: false
-        type: string
     outputs:
       version:
         value: ${{ inputs.version }}
@@ -159,4 +156,3 @@ jobs:
       checkout-version: ${{ inputs.checkout-version }}
       dry-run: ${{ inputs.dry-run }}
       working-directory: ${{ inputs.working-directory }}
-      corectl-version: ${{ inputs.corectl-version }}

--- a/p2p.mk
+++ b/p2p.mk
@@ -73,10 +73,9 @@ p2p-images:
 .PHONY: p2p-promote-to-extended-test ## Promote to extended test
 p2p-promote-to-extended-test:
 	$(foreach image, $(P2P_IMAGE_NAMES), \
-		corectl p2p promote "$(image):$(P2P_VERSION)" \
-			--source-stage "$(P2P_REGISTRY_FAST_FEEDBACK_PATH)" \
-			--dest-registry "$(P2P_REGISTRY)" \
-			--dest-stage "$(P2P_REGISTRY_EXTENDED_TEST_PATH)" \
+		skopeo copy --all --preserve-digests \
+			docker://$(SOURCE_REGISTRY)/$(P2P_REGISTRY_FAST_FEEDBACK_PATH)/$(image):$(P2P_VERSION) \
+			docker://$(REGISTRY)/$(P2P_REGISTRY_EXTENDED_TEST_PATH)/$(image):$(P2P_VERSION) \
 	;)
 
 .PHONY: p2p-extended-test ## Run extended tests
@@ -90,10 +89,9 @@ p2p-promote-to-extended-test:
 .PHONY: p2p-promote-to-prod ## Promote to prod
 p2p-promote-to-prod:
 	$(foreach image, $(P2P_IMAGE_NAMES), \
-		corectl p2p promote "$(image):$(P2P_VERSION)" \
-			--source-stage "$(P2P_REGISTRY_EXTENDED_TEST_PATH)" \
-			--dest-registry "$(P2P_REGISTRY)" \
-			--dest-stage "$(P2P_REGISTRY_PROD_PATH)" \
+		skopeo copy --all --preserve-digests \
+			docker://$(SOURCE_REGISTRY)/$(P2P_REGISTRY_EXTENDED_TEST_PATH)/$(image):$(P2P_VERSION) \
+			docker://$(REGISTRY)/$(P2P_REGISTRY_PROD_PATH)/$(image):$(P2P_VERSION) \
 	;)
 
 .PHONY: p2p-prod ## Deploy to prod


### PR DESCRIPTION
corectl p2p promote was basically just doing docker login and docker pull / push.
this replaces it with skopeo login and skopeo copy which is more efficient and also supports other types of images, eg helm oci images.