### PR TITLE
Add skip-subnamespace-create option

### DIFF
--- a/.github/workflows/p2p-execute-command.yaml
+++ b/.github/workflows/p2p-execute-command.yaml
@@ -59,6 +59,12 @@ on:
         required: false
         type: string
         default: '.'
+      skip-subnamespaces-create:
+        description: |
+          Skip creating subnamespaces
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   exec:
@@ -159,7 +165,7 @@ jobs:
 
       - name: ${{ inputs.subnamespace == '' && 'Setup subnamespace' || format('Setup subnamespace {0}', inputs.app-name != vars.TENANT_NAME && format('{0}-{1}-{2}', vars.TENANT_NAME, inputs.app-name, inputs.subnamespace) || format('{0}-{1}', vars.TENANT_NAME, inputs.subnamespace)) }}
         id: setup-subnamespace
-        if: ${{ inputs.dry-run == false && inputs.app-name != '' && inputs.subnamespace != '' }}
+        if: ${{ inputs.dry-run == false && inputs.skip-subnamespaces-create == false && inputs.app-name != '' && inputs.subnamespace != '' }}
         run: |
           if [[ "${{ vars.TENANT_NAME }}" == "${{ inputs.app-name }}" ]]; then
             SUBNAMESPACE="${{ vars.TENANT_NAME }}-${{ inputs.subnamespace }}"

--- a/.github/workflows/p2p-workflow-extended-test.yaml
+++ b/.github/workflows/p2p-workflow-extended-test.yaml
@@ -45,6 +45,12 @@ on:
         required: false
         type: string
         default: 'v'
+      skip-subnamespaces-create:
+        description: |
+          Skip creating subnamespaces
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   run-tests:
@@ -68,6 +74,7 @@ jobs:
       dry-run: ${{ inputs.dry-run }}
       working-directory: ${{ inputs.working-directory }}
       checkout-version: ${{ inputs.version-prefix }}${{ inputs.version }}
+      skip-subnamespaces-create: ${{ inputs.skip-subnamespaces-create }}
 
   promote:
     uses: ./.github/workflows/p2p-promote-image.yaml

--- a/.github/workflows/p2p-workflow-fastfeedback.yaml
+++ b/.github/workflows/p2p-workflow-fastfeedback.yaml
@@ -49,6 +49,12 @@ on:
         required: false
         type: boolean
         default: false
+      skip-subnamespaces-create:
+        description: |
+          Skip creating subnamespaces
+        required: false
+        type: boolean
+        default: false
     outputs:
       version:
         value: ${{ inputs.version }}
@@ -73,6 +79,7 @@ jobs:
       dry-run: ${{ inputs.dry-run }}
       region: ${{ inputs.region }}
       working-directory: ${{ inputs.working-directory }}
+      skip-subnamespaces-create: ${{ inputs.skip-subnamespaces-create }}
 
   functional-test:
     needs: [build]
@@ -95,6 +102,7 @@ jobs:
       checkout-version: ${{ inputs.checkout-version }}
       dry-run: ${{ inputs.dry-run }}
       working-directory: ${{ inputs.working-directory }}
+      skip-subnamespaces-create: ${{ inputs.skip-subnamespaces-create }}
 
   nft-test:
     needs: [build]
@@ -117,6 +125,7 @@ jobs:
       checkout-version: ${{ inputs.checkout-version }}
       dry-run: ${{ inputs.dry-run }}
       working-directory: ${{ inputs.working-directory }}
+      skip-subnamespaces-create: ${{ inputs.skip-subnamespaces-create }}
 
   integration-test:
     needs: [functional-test, nft-test]
@@ -140,6 +149,7 @@ jobs:
       checkout-version: ${{ inputs.checkout-version }}
       dry-run: ${{ inputs.dry-run }}
       working-directory: ${{ inputs.working-directory }}
+      skip-subnamespaces-create: ${{ inputs.skip-subnamespaces-create }}
 
   promote:
     name: promote

--- a/.github/workflows/p2p-workflow-prod.yaml
+++ b/.github/workflows/p2p-workflow-prod.yaml
@@ -42,6 +42,12 @@ on:
         required: false
         type: string
         default: 'v'
+      skip-subnamespaces-create:
+        description: |
+          Skip creating subnamespaces
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   prod-deploy:
@@ -66,3 +72,4 @@ jobs:
       dry-run: ${{ inputs.dry-run }}
       working-directory: ${{ inputs.working-directory }}
       checkout-version: ${{ inputs.version-prefix }}${{ inputs.version }}
+      skip-subnamespaces-create: ${{ inputs.skip-subnamespaces-create }}


### PR DESCRIPTION
Add an optional, default to false `skip-subnamespaces-create` input, useful for apps that don't deploy to k8s (eg infra)
