### PR TITLE
Improve multi-region support

### DIFF
--- a/.github/workflows/p2p-execute-command.yaml
+++ b/.github/workflows/p2p-execute-command.yaml
@@ -90,8 +90,8 @@ jobs:
       PLATFORM_ENVIRONMENT: ${{ vars.DPLATFORM }}
       PROJECT_ID: ${{ vars.PROJECT_ID }}
       PROJECT_NUMBER: ${{ vars.PROJECT_NUMBER }}
-      REGION: ${{ inputs.region }}
-      REGISTRY: ${{ inputs.region }}-docker.pkg.dev/${{ vars.PROJECT_ID }}/tenant/${{ inputs.tenant-name != '' && inputs.tenant-name || vars.TENANT_NAME }}
+      REGION: ${{ vars.REGION || inputs.region }}
+      REGISTRY: ${{ vars.REGION || inputs.region }}-docker.pkg.dev/${{ vars.PROJECT_ID }}/tenant/${{ inputs.tenant-name != '' && inputs.tenant-name || vars.TENANT_NAME }}
       VERSION: ${{ inputs.version }}
       SERVICE_ACCOUNT: p2p-${{ inputs.tenant-name != '' && inputs.tenant-name || vars.TENANT_NAME }}@${{ vars.PROJECT_ID }}.iam.gserviceaccount.com
       TENANT_NAME: ${{ inputs.tenant-name != '' && inputs.tenant-name || vars.TENANT_NAME }}
@@ -131,9 +131,9 @@ jobs:
         if: ${{ inputs.dry-run == false }}
         uses: google-github-actions/get-gke-credentials@v2
         with:
-          context_name: gke_${{ env.PROJECT_ID }}_${{ inputs.region }}_${{ env.DPLATFORM }}
+          context_name: gke_${{ env.PROJECT_ID }}_${{ env.REGION }}_${{ env.DPLATFORM }}
           cluster_name: ${{ env.DPLATFORM }}
-          location: ${{ inputs.region }}
+          location: ${{ env.REGION }}
           project_id: ${{ env.PROJECT_ID }}
           use_dns_based_endpoint: true
 
@@ -166,7 +166,7 @@ jobs:
         uses: docker/login-action@v3
         if: ${{ inputs.dry-run == false }}
         with:
-          registry: ${{ inputs.region }}-docker.pkg.dev
+          registry: ${{ env.REGION }}-docker.pkg.dev
           username: oauth2accesstoken
           password: ${{ steps.auth.outputs.access_token }}
 
@@ -220,7 +220,7 @@ jobs:
           export P2P_TENANT_NAME="${{ env.TENANT_NAME }}"
           export P2P_APP_NAME=${{ inputs.app-name }}
           export P2P_VERSION=${{ inputs.version }}
-          export P2P_REGISTRY=${{ inputs.region }}-docker.pkg.dev/${{ vars.PROJECT_ID }}/tenant/${{ env.TENANT_NAME }}
+          export P2P_REGISTRY=${{ env.REGION }}-docker.pkg.dev/${{ vars.PROJECT_ID }}/tenant/${{ env.TENANT_NAME }}
           export P2P_REGISTRY_FAST_FEEDBACK_PATH=fast-feedback
           export P2P_REGISTRY_EXTENDED_TEST_PATH=extended-test
           export P2P_REGISTRY_PROD_PATH=prod

--- a/.github/workflows/p2p-promote-image.yaml
+++ b/.github/workflows/p2p-promote-image.yaml
@@ -49,7 +49,7 @@ jobs:
     environment: ${{ fromJson(inputs.source_matrix).include[0]['deploy_env'] }}
     env:
       TENANT_NAME: ${{ inputs.tenant-name != '' && inputs.tenant-name || vars.TENANT_NAME }}
-      REGISTRY: ${{ inputs.region }}-docker.pkg.dev/${{ vars.PROJECT_ID }}/tenant/${{ inputs.tenant-name != '' && inputs.tenant-name || vars.TENANT_NAME }}
+      REGISTRY: ${{ vars.REGION || inputs.region }}-docker.pkg.dev/${{ vars.PROJECT_ID }}/tenant/${{ inputs.tenant-name != '' && inputs.tenant-name || vars.TENANT_NAME }}
       PROJECT_ID: ${{ vars.PROJECT_ID }}
       SERVICE_ACCOUNT: p2p-${{ inputs.tenant-name != '' && inputs.tenant-name || vars.TENANT_NAME }}@${{ vars.PROJECT_ID }}.iam.gserviceaccount.com
       WORKLOAD_IDENTITY_PROVIDER: projects/${{ vars.PROJECT_NUMBER }}/locations/global/workloadIdentityPools/p2p-${{ inputs.tenant-name != '' && inputs.tenant-name || vars.TENANT_NAME }}/providers/p2p-${{ inputs.tenant-name != '' && inputs.tenant-name || vars.TENANT_NAME }}
@@ -78,8 +78,8 @@ jobs:
       DPLATFORM: ${{ vars.DPLATFORM }}
       PROJECT_ID: ${{ vars.PROJECT_ID }}
       PROJECT_NUMBER: ${{ vars.PROJECT_NUMBER }}
-      REGION: ${{ inputs.region }}
-      REGISTRY: ${{ inputs.region }}-docker.pkg.dev/${{ vars.PROJECT_ID }}/tenant/${{ inputs.tenant-name != '' && inputs.tenant-name || vars.TENANT_NAME }}
+      REGION: ${{ vars.REGION || inputs.region }}
+      REGISTRY: ${{ vars.REGION || inputs.region }}-docker.pkg.dev/${{ vars.PROJECT_ID }}/tenant/${{ inputs.tenant-name != '' && inputs.tenant-name || vars.TENANT_NAME }}
       SERVICE_ACCOUNT: p2p-${{ inputs.tenant-name != '' && inputs.tenant-name || vars.TENANT_NAME }}@${{ vars.PROJECT_ID }}.iam.gserviceaccount.com
       VERSION: ${{ inputs.version }}
       SOURCE_GITHUB_ENV: ${{ fromJson(inputs.source_matrix).include[0]['deploy_env'] }}
@@ -148,7 +148,7 @@ jobs:
           export P2P_TENANT_NAME="${{ env.TENANT_NAME }}"
           export P2P_APP_NAME=${{ inputs.app-name }}
           export P2P_VERSION=${{ inputs.version }}
-          export P2P_REGISTRY=${{ inputs.region }}-docker.pkg.dev/${{ vars.PROJECT_ID }}/tenant/${{ env.TENANT_NAME }}
+          export P2P_REGISTRY=${{ env.REGION }}-docker.pkg.dev/${{ vars.PROJECT_ID }}/tenant/${{ env.TENANT_NAME }}
           export P2P_REGISTRY_FAST_FEEDBACK_PATH=fast-feedback
           export P2P_REGISTRY_EXTENDED_TEST_PATH=extended-test
           export P2P_REGISTRY_PROD_PATH=prod


### PR DESCRIPTION
## Summary

- `p2p-execute-command.yaml`: resolve `REGION` and `REGISTRY` from `vars.REGION || inputs.region`; replace all downstream `${{ inputs.region }}` references with `${{ env.REGION }}`
- `p2p-promote-image.yaml`: use `vars.REGION || inputs.region` in both the `lookup` job (source environment context) and the `promote-image` job (destination environment context)

## Motivation

Both workflows already set `environment:` to the relevant GitHub environment on each job, meaning `vars.REGION` is correctly scoped per-environment at runtime. Previously, a single `inputs.region` was threaded through all jobs in a stage, causing every matrix job to use the same region even when environments in that stage were in different regions.

The `|| inputs.region` fallback preserves full backwards compatibility: existing environments without `REGION` set continue to use the value passed by the caller (defaulting to `europe-west2`).

This pairs with the `core-platform` change that writes `REGION` alongside `PROJECT_ID` and `PROJECT_NUMBER` when setting up GitHub environments.
