### PR TITLE
fix: correct hardcoded vars references in p2p workflows

### DIFF
--- a/.github/workflows/p2p-execute-command.yaml
+++ b/.github/workflows/p2p-execute-command.yaml
@@ -220,7 +220,7 @@ jobs:
           export P2P_TENANT_NAME="${{ env.TENANT_NAME }}"
           export P2P_APP_NAME=${{ inputs.app-name }}
           export P2P_VERSION=${{ inputs.version }}
-          export P2P_REGISTRY=${{ env.REGION }}-docker.pkg.dev/${{ vars.PROJECT_ID }}/tenant/${{ env.TENANT_NAME }}
+          export P2P_REGISTRY=${{ env.REGION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/tenant/${{ env.TENANT_NAME }}
           export P2P_REGISTRY_FAST_FEEDBACK_PATH=fast-feedback
           export P2P_REGISTRY_EXTENDED_TEST_PATH=extended-test
           export P2P_REGISTRY_PROD_PATH=prod

--- a/.github/workflows/p2p-get-latest-image-extended-test.yaml
+++ b/.github/workflows/p2p-get-latest-image-extended-test.yaml
@@ -47,7 +47,7 @@ jobs:
     secrets:
       env_vars: ${{ secrets.env_vars }}
     strategy:
-      matrix: ${{ fromJSON(vars.EXTENDED_TEST) }}
+      matrix: ${{ fromJSON(inputs.environment) }}
       fail-fast: false
     with:
       environment: ${{ inputs.environment }}

--- a/.github/workflows/p2p-get-latest-image.yaml
+++ b/.github/workflows/p2p-get-latest-image.yaml
@@ -53,7 +53,7 @@ jobs:
       REGION: ${{ vars.REGION || inputs.region }}
       REGISTRY: ${{ vars.REGION || inputs.region }}-docker.pkg.dev/${{ vars.PROJECT_ID }}/tenant/${{ inputs.tenant-name != '' && inputs.tenant-name || vars.TENANT_NAME }}
       SERVICE_ACCOUNT: p2p-${{ inputs.tenant-name != '' && inputs.tenant-name || vars.TENANT_NAME }}@${{ vars.PROJECT_ID }}.iam.gserviceaccount.com
-      GITHUB_ENV: ${{ fromJson(inputs.environment).include[0]['deploy_env'] }}
+      ENV_NAME: ${{ fromJson(inputs.environment).include[0]['deploy_env'] }}
       TENANT_NAME: ${{ inputs.tenant-name != '' && inputs.tenant-name || vars.TENANT_NAME }}
       WORKLOAD_IDENTITY_PROVIDER: projects/${{ vars.PROJECT_NUMBER }}/locations/global/workloadIdentityPools/p2p-${{ inputs.tenant-name != '' && inputs.tenant-name || vars.TENANT_NAME }}/providers/p2p-${{ inputs.tenant-name != '' && inputs.tenant-name || vars.TENANT_NAME }}
       REGISTRY_PATH: ${{ inputs.registry-path }}

--- a/.github/workflows/p2p-promote-image.yaml
+++ b/.github/workflows/p2p-promote-image.yaml
@@ -148,7 +148,7 @@ jobs:
           export P2P_TENANT_NAME="${{ env.TENANT_NAME }}"
           export P2P_APP_NAME=${{ inputs.app-name }}
           export P2P_VERSION=${{ inputs.version }}
-          export P2P_REGISTRY=${{ env.REGION }}-docker.pkg.dev/${{ vars.PROJECT_ID }}/tenant/${{ env.TENANT_NAME }}
+          export P2P_REGISTRY=${{ env.REGION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/tenant/${{ env.TENANT_NAME }}
           export P2P_REGISTRY_FAST_FEEDBACK_PATH=fast-feedback
           export P2P_REGISTRY_EXTENDED_TEST_PATH=extended-test
           export P2P_REGISTRY_PROD_PATH=prod


### PR DESCRIPTION
## Summary

Four independent bugfixes for P2P reusable workflows:

- **`p2p-get-latest-image-extended-test`**: `strategy.matrix` uses `fromJSON(vars.EXTENDED_TEST)` instead of `fromJSON(inputs.environment)` — ignoring the caller's `environment` input. The prod variant (`p2p-get-latest-image-prod`) already uses `fromJSON(inputs.environment)` correctly.

- **`p2p-execute-command`**: "Set p2p variables" step uses `${{ vars.PROJECT_ID }}` instead of `${{ env.PROJECT_ID }}` — bypasses the job-level `env:` block, meaning any `GITHUB_ENV` overrides to `PROJECT_ID` are ignored.

- **`p2p-promote-image`**: Same `vars.PROJECT_ID` → `env.PROJECT_ID` fix in the "Set p2p variables" step.

- **`p2p-get-latest-image`**: The job `env:` block defines `GITHUB_ENV` as an environment variable (set to the deploy env name), which shadows the runner's special `GITHUB_ENV` file path. Renamed to `ENV_NAME`. The variable is not referenced by any step, so this is a safe rename.