### PR TITLE
Update dependencies

### DIFF
--- a/.github/workflows/internal-version.yaml
+++ b/.github/workflows/internal-version.yaml
@@ -31,7 +31,7 @@ jobs:
       version: ${{ steps.setversion.outputs.patch }}
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         fetch-depth: 0
     - name: Configure Git

--- a/.github/workflows/p2p-execute-command.yaml
+++ b/.github/workflows/p2p-execute-command.yaml
@@ -104,14 +104,14 @@ jobs:
           EOT
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ inputs.dry-run == false && inputs.checkout-version || '' }}
 
       - name: Authenticate to Google Cloud
         id: auth
         if: ${{ inputs.dry-run == false }}
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v3
         with:
           workload_identity_provider: ${{ env.WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ env.SERVICE_ACCOUNT }}
@@ -122,14 +122,14 @@ jobs:
       - name: Setup Google Cloud SDK
         id: setup-gcloud
         if: ${{ inputs.dry-run == false }}
-        uses: google-github-actions/setup-gcloud@v2
+        uses: google-github-actions/setup-gcloud@v3
         with:
           skip_install: true
 
       - name: Setup kubeconfig
         id: setup-kubeconfig
         if: ${{ inputs.dry-run == false }}
-        uses: google-github-actions/get-gke-credentials@v2
+        uses: google-github-actions/get-gke-credentials@v3
         with:
           context_name: gke_${{ env.PROJECT_ID }}_${{ env.REGION }}_${{ env.DPLATFORM }}
           cluster_name: ${{ env.DPLATFORM }}
@@ -145,7 +145,7 @@ jobs:
 
       - name: Setup Docker Buildx
         id: setup-docker-buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
         with:
           driver-opts: |
             default-load=true
@@ -160,10 +160,10 @@ jobs:
 
       - name: Expose GitHub Runtime
         id: expose-github-runtime
-        uses: crazy-max/ghaction-github-runtime@v3
+        uses: crazy-max/ghaction-github-runtime@v4
 
       - name: Login to Artifact Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         if: ${{ inputs.dry-run == false }}
         with:
           registry: ${{ env.REGION }}-docker.pkg.dev
@@ -292,7 +292,7 @@ jobs:
 
       - name: Upload artifacts
         if: ${{ always() && steps.resolve-artifacts.outputs.paths != '' }}
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ inputs.command }}-${{ inputs.github_env || 'noenv' }}-run${{ github.run_number }}-attempt${{ github.run_attempt }}
           path: ${{ steps.resolve-artifacts.outputs.paths }}

--- a/.github/workflows/p2p-get-latest-image.yaml
+++ b/.github/workflows/p2p-get-latest-image.yaml
@@ -72,7 +72,7 @@ jobs:
       - name: Authenticate to Google Cloud
         id: auth
         if: inputs.dry-run == false
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v3
         with:
           export_environment_variables: true
           workload_identity_provider: ${{ env.WORKLOAD_IDENTITY_PROVIDER }}

--- a/.github/workflows/p2p-promote-image.yaml
+++ b/.github/workflows/p2p-promote-image.yaml
@@ -101,7 +101,7 @@ jobs:
           EOT
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ inputs.dry-run == false && inputs.checkout-version || '' }}
 
@@ -109,7 +109,7 @@ jobs:
       - name: Authenticate to Google Cloud (Source)
         id: auth-source
         if: inputs.dry-run == false
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v3
         with:
           export_environment_variables: false
           workload_identity_provider: ${{ env.SOURCE_WORKLOAD_IDENTITY_PROVIDER }}
@@ -122,7 +122,7 @@ jobs:
       - name: Authenticate to Google Cloud (Dest)
         id: auth-dest
         if: inputs.dry-run == false
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v3
         with:
           export_environment_variables: false
           workload_identity_provider: ${{ env.WORKLOAD_IDENTITY_PROVIDER }}

--- a/.github/workflows/p2p-version.yaml
+++ b/.github/workflows/p2p-version.yaml
@@ -39,7 +39,7 @@ jobs:
       previous_version: ${{ steps.setversion.outputs.previous_version }}
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         fetch-depth: 0
         ref: ${{ inputs.checkout-version }}

--- a/.github/workflows/platform-cd.yaml
+++ b/.github/workflows/platform-cd.yaml
@@ -37,7 +37,7 @@ jobs:
     steps:
       - id: checkout
         name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - uses: dorny/paths-filter@v3
         id: filter
         with:

--- a/.github/workflows/platform-ci.yaml
+++ b/.github/workflows/platform-ci.yaml
@@ -37,7 +37,7 @@ jobs:
     steps:
       - id: checkout
         name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - uses: dorny/paths-filter@v3
         id: filter
         with:

--- a/.github/workflows/platform-environment-feature-matrix.yaml
+++ b/.github/workflows/platform-environment-feature-matrix.yaml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - id: checkout
         name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - id: generate-matrix
         name: Generate Matrix

--- a/.github/workflows/platform-environment-matrix.yaml
+++ b/.github/workflows/platform-environment-matrix.yaml
@@ -28,7 +28,7 @@ jobs:
     steps:
       - id: checkout
         name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - id: generate-matrix
         name: Generate Matrix

--- a/.github/workflows/platform-execute-command.yaml
+++ b/.github/workflows/platform-execute-command.yaml
@@ -73,12 +73,12 @@ jobs:
     steps:
       - id: checkout
         name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - id: auth-aws
         if: inputs.platform == 'aws'
         name: Authenticate to AWS
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ vars.AWS_ROLE_ARN }}
           aws-region: ${{ vars.AWS_REGION }}
@@ -86,7 +86,7 @@ jobs:
       - id: auth-azure
         if: inputs.platform == 'azure'
         name: Authenticate to Azure
-        uses: azure/login@v1.5.1
+        uses: azure/login@v2.3.0
         with:
           client-id: ${{ vars.AZURE_CLIENT_ID }}
           tenant-id: ${{ vars.AZURE_TENANT_ID }}
@@ -95,7 +95,7 @@ jobs:
       - id: auth-gcloud
         if: inputs.platform == 'gcp'
         name: Authenticate to GCP
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v3
         with:
           workload_identity_provider: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ vars.GCP_SERVICE_ACCOUNT }}

--- a/.github/workflows/platform-release.yaml
+++ b/.github/workflows/platform-release.yaml
@@ -33,7 +33,7 @@ jobs:
     steps:
       - id: checkout
         name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - id: publish-pkg
         name: Publish go pkg
@@ -54,7 +54,7 @@ jobs:
     steps:
       - id: checkout
         name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - id: source-date-epoch
         name: Source date epoch
@@ -72,11 +72,11 @@ jobs:
 
       - id: docker-setup-buildx
         name: Setup Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - id: docker-login
         name: Login to the registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ inputs.registry }}
           username: ${{ github.actor }}
@@ -84,7 +84,7 @@ jobs:
 
       - id: metadata
         name: Metadata
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ inputs.registry }}/${{ inputs.image_name }}
           labels: |
@@ -97,7 +97,7 @@ jobs:
 
       - id: go-build-cache
         name: Go build cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: go-build-cache
           key: ${{ runner.os }}-go-build-cache-${{ hashFiles('**/go.sum') }}
@@ -119,7 +119,7 @@ jobs:
 
       - id: build-push
         name: Build and push
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           cache-from: type=gha


### PR DESCRIPTION
- actions/checkout@v6 (was @v4)
- actions/cache@v5 (was @v4)
- actions/upload-artifact@v7 (was @v6)
- google-github-actions/auth@v3 / setup-gcloud@v3 / get-gke-credentials@v3 (were @v2)
- docker/*@v4|v6|v7 majors as applicable (were older majors)
- aws-actions/configure-aws-credentials@v6 (was @v4)
- dorny/paths-filter@v3 (kept major-only)
- WyriHaximus/github-action-next-semvers@v1, rickstaa/action-create-tag@v1, coreeng/action-create-tag@v1 (kept major-only)