### PR TITLE
Add optional Slack alerts

### DIFF
--- a/.github/workflows/p2p-get-latest-image-extended-test.yaml
+++ b/.github/workflows/p2p-get-latest-image-extended-test.yaml
@@ -3,6 +3,8 @@ on:
     secrets:
       env_vars:
         required: false
+      slack_webhook_url:
+        required: false
     outputs:
       version:
         description: "The latest image in the registry"
@@ -57,3 +59,25 @@ jobs:
       dry-run: ${{ inputs.dry-run }}
       working-directory: ${{ inputs.working-directory }}
       region: ${{ inputs.region }}
+
+  failure-alert:
+    needs: [get-latest-version]
+    name: Slack failure alert
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    if: always() && github.ref == inputs.main-branch && contains(needs.*.result, 'failure')
+
+    env:
+      SLACK_WEBHOOK_URL: ${{ secrets.slack_webhook_url }}
+
+    steps:
+      - id: slack-alert
+        name: Slack alert
+        uses: slackapi/slack-github-action@v2
+        if: env.SLACK_WEBHOOK_URL != ''
+        with:
+          webhook: ${{ env.SLACK_WEBHOOK_URL }}
+          webhook-type: webhook-trigger
+          payload: |
+            notification: "P2P get-latest-image (extended-test) failed"
+            workflow_link: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/.github/workflows/p2p-get-latest-image-prod.yaml
+++ b/.github/workflows/p2p-get-latest-image-prod.yaml
@@ -3,6 +3,8 @@ on:
     secrets:
       env_vars:
         required: false
+      slack_webhook_url:
+        required: false
     outputs:
       version:
         description: "The latest image in the registry"
@@ -57,3 +59,25 @@ jobs:
       dry-run: ${{ inputs.dry-run }}
       working-directory: ${{ inputs.working-directory }}
       region: ${{ inputs.region }}
+
+  failure-alert:
+    needs: [get-latest-version]
+    name: Slack failure alert
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    if: always() && github.ref == inputs.main-branch && contains(needs.*.result, 'failure')
+
+    env:
+      SLACK_WEBHOOK_URL: ${{ secrets.slack_webhook_url }}
+
+    steps:
+      - id: slack-alert
+        name: Slack alert
+        uses: slackapi/slack-github-action@v2
+        if: env.SLACK_WEBHOOK_URL != ''
+        with:
+          webhook: ${{ env.SLACK_WEBHOOK_URL }}
+          webhook-type: webhook-trigger
+          payload: |
+            notification: "P2P get-latest-image (prod) failed"
+            workflow_link: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/.github/workflows/p2p-version.yaml
+++ b/.github/workflows/p2p-version.yaml
@@ -12,6 +12,8 @@ on:
     secrets:
       git-token:
         required: true
+      slack_webhook_url:
+        required: false
     inputs:
       main-branch:
         required: false
@@ -131,3 +133,25 @@ jobs:
       shell: bash
       run: |
         echo "Output version: ${{ steps.setversion.outputs.version }}"
+
+  failure-alert:
+    needs: [increment-version]
+    name: Slack failure alert
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    if: always() && github.ref == inputs.main-branch && contains(needs.*.result, 'failure')
+
+    env:
+      SLACK_WEBHOOK_URL: ${{ secrets.slack_webhook_url }}
+
+    steps:
+      - id: slack-alert
+        name: Slack alert
+        uses: slackapi/slack-github-action@v2
+        if: env.SLACK_WEBHOOK_URL != ''
+        with:
+          webhook: ${{ env.SLACK_WEBHOOK_URL }}
+          webhook-type: webhook-trigger
+          payload: |
+            notification: "P2P version workflow failed"
+            workflow_link: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/.github/workflows/p2p-workflow-extended-test.yaml
+++ b/.github/workflows/p2p-workflow-extended-test.yaml
@@ -9,6 +9,8 @@ on:
         required: false
       container_registry_url:
         required: false
+      slack_webhook_url:
+        required: false
     inputs:
       source:
         required: false
@@ -106,3 +108,27 @@ jobs:
       dry-run: ${{ inputs.dry-run }}
       working-directory: ${{ inputs.working-directory }}
       checkout-version: ${{ inputs.version-prefix }}${{ inputs.version }}
+
+  failure-alert:
+    needs: [run-tests, promote]
+    name: Slack failure alert
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    if: always() && github.ref == inputs.main-branch && contains(needs.*.result, 'failure')
+
+    env:
+      SLACK_WEBHOOK_URL: ${{ secrets.slack_webhook_url }}
+
+    steps:
+      - id: slack-alert
+        name: Slack alert
+        uses: slackapi/slack-github-action@v2
+        if: env.SLACK_WEBHOOK_URL != ''
+        with:
+          webhook: ${{ env.SLACK_WEBHOOK_URL }}
+          webhook-type: webhook-trigger
+          payload: |
+            notification: "❌ P2P extended-test failed: *${{ inputs.app-name != '' && inputs.app-name || github.event.repository.name }}* @ *${{ inputs.version }}*"
+            app_name: "${{ inputs.app-name != '' && inputs.app-name || github.event.repository.name }}"
+            version: "${{ inputs.version }}"
+            workflow_link: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/.github/workflows/p2p-workflow-fastfeedback.yaml
+++ b/.github/workflows/p2p-workflow-fastfeedback.yaml
@@ -9,6 +9,8 @@ on:
         required: false
       container_registry_url:
         required: false
+      slack_webhook_url:
+        required: false
     inputs:
       dry-run:
         required: false
@@ -188,3 +190,27 @@ jobs:
       checkout-version: ${{ inputs.checkout-version }}
       dry-run: ${{ inputs.dry-run }}
       working-directory: ${{ inputs.working-directory }}
+
+  failure-alert:
+    needs: [build, functional-test, nft-test, integration-test, promote]
+    name: Slack failure alert
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    if: always() && github.ref == inputs.main-branch && contains(needs.*.result, 'failure')
+
+    env:
+      SLACK_WEBHOOK_URL: ${{ secrets.slack_webhook_url }}
+
+    steps:
+      - id: slack-alert
+        name: Slack alert
+        uses: slackapi/slack-github-action@v2
+        if: env.SLACK_WEBHOOK_URL != ''
+        with:
+          webhook: ${{ env.SLACK_WEBHOOK_URL }}
+          webhook-type: webhook-trigger
+          payload: |
+            notification: "❌ P2P fast-feedback failed: *${{ inputs.app-name != '' && inputs.app-name || github.event.repository.name }}* @ *${{ inputs.version }}*"
+            app_name: "${{ inputs.app-name != '' && inputs.app-name || github.event.repository.name }}"
+            version: "${{ inputs.version }}"
+            workflow_link: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/.github/workflows/p2p-workflow-prod.yaml
+++ b/.github/workflows/p2p-workflow-prod.yaml
@@ -9,6 +9,8 @@ on:
         required: false
       container_registry_url:
         required: false
+      slack_webhook_url:
+        required: false
     inputs:
       source:
         required: false
@@ -78,3 +80,51 @@ jobs:
       working-directory: ${{ inputs.working-directory }}
       checkout-version: ${{ inputs.version-prefix }}${{ inputs.version }}
       skip-subnamespaces-create: ${{ inputs.skip-subnamespaces-create }}
+
+  failure-alert:
+    needs: [prod-deploy]
+    name: Slack failure alert
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    if: always() && github.ref == inputs.main-branch && contains(needs.*.result, 'failure')
+
+    env:
+      SLACK_WEBHOOK_URL: ${{ secrets.slack_webhook_url }}
+
+    steps:
+      - id: slack-alert
+        name: Slack alert
+        uses: slackapi/slack-github-action@v2
+        if: env.SLACK_WEBHOOK_URL != ''
+        with:
+          webhook: ${{ env.SLACK_WEBHOOK_URL }}
+          webhook-type: webhook-trigger
+          payload: |
+            notification: "❌ P2P prod failed: *${{ inputs.app-name != '' && inputs.app-name || github.event.repository.name }}* @ *${{ inputs.version }}*"
+            app_name: "${{ inputs.app-name != '' && inputs.app-name || github.event.repository.name }}"
+            version: "${{ inputs.version }}"
+            workflow_link: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+
+  success-alert:
+    needs: [prod-deploy]
+    name: Slack success alert
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    if: github.ref == inputs.main-branch && needs.prod-deploy.result == 'success' && inputs.dry-run == false
+
+    env:
+      SLACK_WEBHOOK_URL: ${{ secrets.slack_webhook_url }}
+
+    steps:
+      - id: slack-alert
+        name: Slack alert
+        uses: slackapi/slack-github-action@v2
+        if: env.SLACK_WEBHOOK_URL != ''
+        with:
+          webhook: ${{ env.SLACK_WEBHOOK_URL }}
+          webhook-type: webhook-trigger
+          payload: |
+            notification: "✅ P2P prod succeeded: *${{ inputs.app-name != '' && inputs.app-name || github.event.repository.name }}* @ *${{ inputs.version }}*"
+            app_name: "${{ inputs.app-name != '' && inputs.app-name || github.event.repository.name }}"
+            version: "${{ inputs.version }}"
+            workflow_link: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/README.md
+++ b/README.md
@@ -112,6 +112,14 @@ These will be used to authenticate to tenant provided registry with tenant's own
 
 Tenant provided registry url. If unspecified, the default of dockerhub will be used
 
+### secrets.slack_webhook_url
+
+Optional Slack Incoming Webhook URL used for failure alerts.
+
+- If set, P2P reusable workflows will send Slack alerts when they fail on the default branch.
+- Additionally, the prod reusable workflow will send a Slack alert when prod succeeds (skips `dry-run`).
+- Recommended: store it as a repo secret named `P2P_SLACK_WEBHOOK_URL`, and pass it through to the reusable workflows as `slack_webhook_url`.
+
 ### dry_run
 
 Typically used for syntax testing. Will run most jobs without actually connecting to them or calling the makefile tasks.


### PR DESCRIPTION
## What
- Add optional Slack alerts to the reusable P2P workflows.

## Alert content
- Notifications prominently include app + version
- Payload includes `app_name`, `version`, and `workflow_link`

## When it alerts
- Only on the default branch (gated by `main-branch` / `github.ref`)
- Only when `secrets.slack_webhook_url` is provided
- Failure alerts: version, get-latest-image, fast-feedback, extended-test, prod
- Success alerts: prod only (except `dry-run`)

## How to enable (callers)
- Create repo secret, recommended name is `P2P_SLACK_WEBHOOK_URL`
- Pass it through to the P2P reusable(s) via `secrets.slack_webhook_url`:

```yaml
secrets:
  slack_webhook_url: ${{ secrets.P2P_SLACK_WEBHOOK_URL }}
```