### PR TITLE
Rename alert jobs

### DIFF
--- a/.github/workflows/p2p-get-latest-image-extended-test.yaml
+++ b/.github/workflows/p2p-get-latest-image-extended-test.yaml
@@ -60,9 +60,8 @@ jobs:
       working-directory: ${{ inputs.working-directory }}
       region: ${{ inputs.region }}
 
-  failure-alert:
+  notify-failure:
     needs: [get-latest-version]
-    name: Slack failure alert
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     if: always() && github.ref == inputs.main-branch && contains(needs.*.result, 'failure')

--- a/.github/workflows/p2p-get-latest-image-prod.yaml
+++ b/.github/workflows/p2p-get-latest-image-prod.yaml
@@ -60,9 +60,8 @@ jobs:
       working-directory: ${{ inputs.working-directory }}
       region: ${{ inputs.region }}
 
-  failure-alert:
+  notify-failure:
     needs: [get-latest-version]
-    name: Slack failure alert
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     if: always() && github.ref == inputs.main-branch && contains(needs.*.result, 'failure')

--- a/.github/workflows/p2p-version.yaml
+++ b/.github/workflows/p2p-version.yaml
@@ -134,9 +134,8 @@ jobs:
       run: |
         echo "Output version: ${{ steps.setversion.outputs.version }}"
 
-  failure-alert:
+  notify-failure:
     needs: [increment-version]
-    name: Slack failure alert
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     if: always() && github.ref == inputs.main-branch && contains(needs.*.result, 'failure')

--- a/.github/workflows/p2p-workflow-extended-test.yaml
+++ b/.github/workflows/p2p-workflow-extended-test.yaml
@@ -109,9 +109,8 @@ jobs:
       working-directory: ${{ inputs.working-directory }}
       checkout-version: ${{ inputs.version-prefix }}${{ inputs.version }}
 
-  failure-alert:
+  notify-failure:
     needs: [run-tests, promote]
-    name: Slack failure alert
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     if: always() && github.ref == inputs.main-branch && contains(needs.*.result, 'failure')

--- a/.github/workflows/p2p-workflow-fastfeedback.yaml
+++ b/.github/workflows/p2p-workflow-fastfeedback.yaml
@@ -191,9 +191,8 @@ jobs:
       dry-run: ${{ inputs.dry-run }}
       working-directory: ${{ inputs.working-directory }}
 
-  failure-alert:
+  notify-failure:
     needs: [build, functional-test, nft-test, integration-test, promote]
-    name: Slack failure alert
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     if: always() && github.ref == inputs.main-branch && contains(needs.*.result, 'failure')

--- a/.github/workflows/p2p-workflow-prod.yaml
+++ b/.github/workflows/p2p-workflow-prod.yaml
@@ -81,9 +81,8 @@ jobs:
       checkout-version: ${{ inputs.version-prefix }}${{ inputs.version }}
       skip-subnamespaces-create: ${{ inputs.skip-subnamespaces-create }}
 
-  failure-alert:
+  notify-failure:
     needs: [prod-deploy]
-    name: Slack failure alert
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     if: always() && github.ref == inputs.main-branch && contains(needs.*.result, 'failure')
@@ -105,9 +104,8 @@ jobs:
             version: "${{ inputs.version }}"
             workflow_link: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
 
-  success-alert:
+  notify-success:
     needs: [prod-deploy]
-    name: Slack success alert
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     if: github.ref == inputs.main-branch && needs.prod-deploy.result == 'success' && inputs.dry-run == false


### PR DESCRIPTION
## What
- Rename the Slack alert job ids to `notify-failure` / `notify-success` to avoid channel-specific naming.
- Remove explicit job `name:` so the displayed job name matches the id.

## Notes
- No interface changes for callers (inputs/secrets unchanged).