### PR TITLE
Fix broken pipe in version workflow

### DIFF
--- a/.github/workflows/p2p-version.yaml
+++ b/.github/workflows/p2p-version.yaml
@@ -57,8 +57,8 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.git-token }}
         VERSION_PREFIX: ${{ inputs.version-prefix }}
       run: |
-        REGEX=$(echo "^${VERSION_PREFIX}([0-9]+)\.([0-9]+)\.([0-9]+)$")
-        PREVIOUS_VERSION=$(git tag | sort -r --version-sort | (grep -E ${REGEX} || echo "") | head -n1 )
+        REGEX="^${VERSION_PREFIX}([0-9]+)\.([0-9]+)\.([0-9]+)$"
+        PREVIOUS_VERSION=$(git tag | grep -E "${REGEX}" | sort -r --version-sort | head -n1 || true)
         [ -z "$PREVIOUS_VERSION" ] && PREVIOUS_VERSION=${VERSION_PREFIX}0.0.0
         echo "tag=$PREVIOUS_VERSION" >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
## Summary
- Fix intermittent "Broken pipe" error in the `Get Previous tag` step of `p2p-version.yaml`
- The pipeline `git tag | sort | (grep || echo) | head -n1` causes SIGPIPE when `head -n1` exits after one line, killing upstream commands
- Fix: move `grep` before `sort` (filter first, sort smaller set) and use `|| true` instead of a subshell

## Root Cause
`head -n1` closes its stdin after reading one line. If `grep` or `sort` is still writing, they receive SIGPIPE and exit with "write error: Broken pipe". This is a race condition — sometimes the timing works, sometimes it doesn't.

## Test plan
- [ ] Trigger a workflow that uses `p2p-version.yaml` and verify the version step passes consistently

🤖 Generated with [Claude Code](https://claude.com/claude-code)