### PR TITLE
Fix get-latest-image environment scoping

### DIFF
--- a/.github/workflows/p2p-get-latest-image-extended-test.yaml
+++ b/.github/workflows/p2p-get-latest-image-extended-test.yaml
@@ -52,7 +52,7 @@ jobs:
       matrix: ${{ fromJSON(inputs.environment) }}
       fail-fast: false
     with:
-      environment: ${{ inputs.environment }}
+      github_env: ${{ matrix.deploy_env }}
       registry-path: ${{ inputs.registry-path }}
       tenant-name: ${{ inputs.tenant-name }}
       image-name: ${{ inputs.image-name }}

--- a/.github/workflows/p2p-get-latest-image-prod.yaml
+++ b/.github/workflows/p2p-get-latest-image-prod.yaml
@@ -52,7 +52,7 @@ jobs:
       matrix: ${{ fromJSON(inputs.environment) }}
       fail-fast: false
     with:
-      environment: ${{ inputs.environment }}
+      github_env: ${{ matrix.deploy_env }}
       registry-path: ${{ inputs.registry-path }}
       tenant-name: ${{ inputs.tenant-name }}
       image-name: ${{ inputs.image-name }}

--- a/.github/workflows/p2p-get-latest-image.yaml
+++ b/.github/workflows/p2p-get-latest-image.yaml
@@ -29,13 +29,13 @@ on:
         required: false
         type: string
         default: europe-west2
+      github_env:
+        required: true
+        type: string
       working-directory:
         required: false
         type: string
         default: '.'
-      environment:
-        required: true
-        type: string
 
 jobs:
   get-latest-image:
@@ -43,7 +43,7 @@ jobs:
     runs-on: ubuntu-24.04
     outputs:
       version: ${{ steps.get-latest-image.outputs.version }}
-    environment: ${{ fromJson(inputs.environment).include[0]['deploy_env'] }}
+    environment: ${{ inputs.github_env }}
     env:
       BASE_DOMAIN: ${{ vars.BASE_DOMAIN }}
       INTERNAL_SERVICES_DOMAIN: ${{ vars.INTERNAL_SERVICES_DOMAIN }}
@@ -53,7 +53,7 @@ jobs:
       REGION: ${{ vars.REGION || inputs.region }}
       REGISTRY: ${{ vars.REGION || inputs.region }}-docker.pkg.dev/${{ vars.PROJECT_ID }}/tenant/${{ inputs.tenant-name != '' && inputs.tenant-name || vars.TENANT_NAME }}
       SERVICE_ACCOUNT: p2p-${{ inputs.tenant-name != '' && inputs.tenant-name || vars.TENANT_NAME }}@${{ vars.PROJECT_ID }}.iam.gserviceaccount.com
-      ENV_NAME: ${{ fromJson(inputs.environment).include[0]['deploy_env'] }}
+      ENV_NAME: ${{ inputs.github_env }}
       TENANT_NAME: ${{ inputs.tenant-name != '' && inputs.tenant-name || vars.TENANT_NAME }}
       WORKLOAD_IDENTITY_PROVIDER: projects/${{ vars.PROJECT_NUMBER }}/locations/global/workloadIdentityPools/p2p-${{ inputs.tenant-name != '' && inputs.tenant-name || vars.TENANT_NAME }}/providers/p2p-${{ inputs.tenant-name != '' && inputs.tenant-name || vars.TENANT_NAME }}
       REGISTRY_PATH: ${{ inputs.registry-path }}


### PR DESCRIPTION
## Summary
- scope the reusable `p2p-get-latest-image` job to a concrete `github_env` instead of resolving the first entry from the matrix JSON
- update the prod and extended-test wrappers to pass `matrix.deploy_env`, so environment-scoped vars like `TENANT_NAME` resolve from the actual calling environment
- keep the existing tenant fallback logic intact while making `get-latest-version` and `get-latest-image` consistent with `p2p-execute-command`