### PR TITLE
Parallelize build stage, serialize version increment

### DIFF
--- a/.github/workflows/p2p-execute-command.yaml
+++ b/.github/workflows/p2p-execute-command.yaml
@@ -80,7 +80,10 @@ jobs:
     runs-on: ubuntu-24.04
     environment: ${{ inputs.github_env }}
     concurrency:
-      group: ${{ inputs.github_env }}/${{ inputs.tenant-name != '' && inputs.tenant-name || vars.TENANT_NAME }}-${{ inputs.app-name }}-${{ inputs.subnamespace }}
+      group: >-
+        ${{ inputs.subnamespace != ''
+        && format('{0}/{1}-{2}-{3}', inputs.github_env, inputs.tenant-name != '' && inputs.tenant-name || vars.TENANT_NAME, inputs.app-name, inputs.subnamespace)
+        || format('{0}/{1}-{2}-build-{3}-{4}', inputs.github_env, inputs.tenant-name != '' && inputs.tenant-name || vars.TENANT_NAME, inputs.app-name, github.run_id, github.run_attempt) }}
       cancel-in-progress: false
     env:
       env_vars: ${{ secrets.env_vars }}

--- a/.github/workflows/p2p-version.yaml
+++ b/.github/workflows/p2p-version.yaml
@@ -36,6 +36,9 @@ jobs:
   increment-version:
     name: increment-version
     runs-on: ubuntu-24.04
+    concurrency:
+      group: increment-version-${{ github.ref }}
+      cancel-in-progress: false
     outputs:
       version: ${{ steps.setversion.outputs.version }}
       previous_version: ${{ steps.setversion.outputs.previous_version }}


### PR DESCRIPTION
## What

Adjusts concurrency on two pipeline stages in the shared (mother) workflows:

- **Build stage → runs in parallel.** The shared `exec` job in `p2p-execute-command.yaml` serialized every stage through one concurrency group. The build stage passes no `subnamespace`, so its group collapsed to `env/tenant-app-` for every run and queued builds one-at-a-time. Build now gets a per-run group (`…-build-<run_id>-<run_attempt>`) so builds run in parallel.
- **Version-increment stage → serialized.** `p2p-version.yaml`'s `increment-version` job had no concurrency control, so parallel runs could both read the latest tag, compute the same next tag, and collide (`tag_exists_error`). It now serializes per ref (`increment-version-${{ github.ref }}`, `cancel-in-progress: false`).

Stages that deploy into a shared subnamespace (`functional`, `nft`, `integration`, `extended`, `prod`) keep their existing serialized group — that behavior is unchanged (the serialized group string is byte-identical to before).

## Why

Build only produces an image and touches no shared per-environment namespace, so it's safe to parallelize. The test/deploy stages and the version tag are shared, mutable state and must stay serialized.

## Notes / scope

- The build fix removes **cross-run** serialization. If two build matrix legs in the *same* run share the same `deploy_env`, they still share a group within that run — `run_id` doesn't distinguish legs. Standard configs use one matrix entry per distinct `deploy_env`, so this is expected to be a non-issue.
- Validated YAML syntax with `yq`; not exercised in a live Actions run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)