### PR TITLE
Tolerate empty images in security scan

### DIFF
--- a/.github/scripts/image-scan-helpers.js
+++ b/.github/scripts/image-scan-helpers.js
@@ -132,7 +132,7 @@ async function scanImages({
   env = process.env,
   fsImpl = fs,
   pathImpl = path,
-  execFileSyncImpl = execFileSync,
+  spawnSyncImpl = spawnSync,
 } = {}) {
   const reportsDir = pathImpl.join(env.RUNNER_TEMP, 'trivy');
   const reportList = pathImpl.join(reportsDir, 'reports.txt');
@@ -161,7 +161,18 @@ async function scanImages({
       target,
     ];
     core.info(`Scanning ${ref} (${plat}) @ ${digest}`);
-    execFileSyncImpl('trivy', args, { stdio: 'inherit' });
+    const proc = spawnSyncImpl('trivy', args, { encoding: 'utf8', maxBuffer: 256 * 1024 * 1024 });
+    if (proc.stdout) process.stdout.write(proc.stdout);
+    if (proc.stderr) process.stderr.write(proc.stderr);
+    if (proc.status !== 0) {
+      const output = `${proc.stdout || ''}\n${proc.stderr || ''}\n${proc.error?.message || ''}`;
+      if (output.includes('empty export - not implemented')) {
+        core.warning?.(`Trivy could not export ${ref} (${plat}); treating empty image as zero vulnerability findings.`);
+        fsImpl.writeFileSync(out, JSON.stringify({ Results: [] }) + '\n');
+      } else {
+        throw new Error(`trivy exited with ${proc.status}: ${proc.stderr || proc.error?.message || '(no stderr)'}`);
+      }
+    }
     fsImpl.appendFileSync(reportList, `${ref}\t${plat}\t${digest}\t${out}\n`);
   }
 }

--- a/.github/scripts/tests/image-scan-targets.test.js
+++ b/.github/scripts/tests/image-scan-targets.test.js
@@ -22,6 +22,7 @@ async function runScanFunction(scanFunction, options = {}) {
   const calls = [];
   const outputs = {};
   const failures = [];
+  const warnings = [];
   const common = {
     env: {
       RUNNER_TEMP: tmp,
@@ -33,15 +34,23 @@ async function runScanFunction(scanFunction, options = {}) {
       setOutput: (key, value) => { outputs[key] = value; },
       setFailed: message => { failures.push(message); },
       info: () => {},
+      warning: message => { warnings.push(message); },
     },
   };
 
   if (scanFunction === scanImages) {
     await scanFunction({
       ...common,
-      execFileSyncImpl(command, args) {
+      spawnSyncImpl(command, args) {
         calls.push({ command, args });
-        return '';
+        if (options.emptyImageExport && calls.length === 1) {
+          return {
+            status: 1,
+            stdout: '',
+            stderr: 'FATAL scan failed: unable to export the image: Error response from daemon: empty export - not implemented',
+          };
+        }
+        return { status: 0, stdout: '', stderr: '' };
       },
     });
   } else {
@@ -81,7 +90,7 @@ async function runScanFunction(scanFunction, options = {}) {
     });
   }
 
-  return { calls, outputs, failures };
+  return { calls, outputs, failures, warnings };
 }
 
 (async () => {
@@ -101,6 +110,14 @@ async function runScanFunction(scanFunction, options = {}) {
       ['--severity', 'UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL'],
     ],
   );
+
+  const emptyImageRun = await runScanFunction(scanImages, { emptyImageExport: true });
+  assert.deepStrictEqual(emptyImageRun.failures, []);
+  assert.deepStrictEqual(emptyImageRun.warnings, [
+    'Trivy could not export europe-west2-docker.pkg.dev/project-a/tenant/tenant-a/prod/api:1.2.3 (linux/amd64); treating empty image as zero vulnerability findings.',
+  ]);
+  const firstReportPath = fs.readFileSync(emptyImageRun.outputs['report-list'], 'utf8').trim().split('\n')[0].split('\t')[3];
+  assert.deepStrictEqual(JSON.parse(fs.readFileSync(firstReportPath, 'utf8')), { Results: [] });
 
   const secretRun = await runScanFunction(secretScanImages);
   assert.deepStrictEqual(secretRun.failures, []);


### PR DESCRIPTION
## Summary
- handle Trivy empty-image export failures as zero vulnerability findings
- emit a warning and write an empty Trivy report so downstream policy/reporting can continue
- add test coverage for the empty export fallback

## Tests
- node .github/scripts/tests/image-scan-targets.test.js
- node .github/scripts/tests/image-scan-manifest.test.js
- node .github/scripts/tests/image-security-ignore-report.test.js
- for test in .github/scripts/tests/*.test.js; do node "" || exit 1; done