### PR TITLE
Skip non-image OCI artifacts during image scans

### DIFF
--- a/.github/scripts/image-scan-helpers.js
+++ b/.github/scripts/image-scan-helpers.js
@@ -80,6 +80,7 @@ async function pullImages({
   const listPath = pathImpl.join(env.RUNNER_TEMP, 'pulled-images.txt');
   fsImpl.writeFileSync(listPath, '');
   core.setOutput('list-path', listPath);
+  let pulledCount = 0;
   for (const ref of refs) {
     // One inspect per ref: `{{json .}}` exposes `.manifest.manifests[]` for OCI indexes / Docker manifest
     // lists, and `.manifest.digest` + `.image.{os,architecture,variant}` for single-manifest images.
@@ -100,9 +101,17 @@ async function pullImages({
                     (m.platform.variant ? `/${m.platform.variant}` : ''),
           digest: m.digest,
         }));
+      if (entries.length === 0 && isNonImageOciArtifact(info)) {
+        core.warning?.(`Skipping ${ref}; it is an OCI artifact, not a container image.`);
+        continue;
+      }
     } else {
       const img = info.image;
       if (!img || !img.os || !img.architecture || !info.manifest?.digest) {
+        if (isNonImageOciArtifact(info)) {
+          core.warning?.(`Skipping ${ref}; it is an OCI artifact, not a container image.`);
+          continue;
+        }
         core.setFailed(`Could not resolve platform/digest for ${ref}.`);
         return;
       }
@@ -119,8 +128,34 @@ async function pullImages({
       core.info(`Pulling ${ref} (${platform}) @ ${digest}`);
       execFileSyncImpl('docker', ['pull', '--platform', platform, ref], { stdio: 'inherit' });
       fsImpl.appendFileSync(listPath, `${ref}\t${platform}\t${digest}\n`);
+      pulledCount += 1;
     }
   }
+  if (pulledCount === 0) {
+    core.setFailed('No container images found to scan after excluding non-image OCI artifacts.');
+  }
+}
+
+function isNonImageOciArtifact(info) {
+  const mediaTypes = [];
+  const addMediaType = value => {
+    if (typeof value === 'string' && value) mediaTypes.push(value);
+  };
+
+  addMediaType(info.mediaType);
+  addMediaType(info.artifactType);
+  addMediaType(info.manifest?.mediaType);
+  addMediaType(info.manifest?.artifactType);
+  addMediaType(info.manifest?.config?.mediaType);
+  if (Array.isArray(info.manifest?.manifests)) {
+    for (const manifest of info.manifest.manifests) {
+      addMediaType(manifest.mediaType);
+      addMediaType(manifest.artifactType);
+      addMediaType(manifest.config?.mediaType);
+    }
+  }
+
+  return mediaTypes.some(type => !type.includes('image'));
 }
 
 function sanitizeReportName(value) {

--- a/.github/scripts/tests/image-scan-manifest.test.js
+++ b/.github/scripts/tests/image-scan-manifest.test.js
@@ -11,6 +11,7 @@ async function runPullScript(imageRefs, inspectByRef) {
   const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'image-pull-'));
   const outputs = {};
   const failures = [];
+  const warnings = [];
   const pulls = [];
 
   await pullImages({
@@ -22,6 +23,7 @@ async function runPullScript(imageRefs, inspectByRef) {
       setOutput: (key, value) => { outputs[key] = value; },
       setFailed: message => { failures.push(message); },
       info: () => {},
+      warning: message => { warnings.push(message); },
     },
     execFileSyncImpl(command, args) {
       assert.strictEqual(command, 'docker');
@@ -38,7 +40,7 @@ async function runPullScript(imageRefs, inspectByRef) {
     },
   });
 
-  return { outputs, failures, pulls };
+  return { outputs, failures, pulls, warnings };
 }
 
 async function runManifestScript({ stage, vulnLines = [], secretLines = [], vulnRawLines = null, secretRawLines = null, setup = null }) {
@@ -137,6 +139,64 @@ async function runManifestScript({ stage, vulnLines = [], secretLines = [], vuln
       'europe-west2-docker.pkg.dev/project-a/tenant/tenant-a/prod/worker:1.2.3\tlinux/arm64\tsha256:arm64',
     ],
   );
+
+  const mixedArtifacts = await runPullScript(
+    [
+      'europe-west2-docker.pkg.dev/project-a/tenant/tenant-a/prod/api:1.2.3',
+      'europe-west2-docker.pkg.dev/project-a/tenant/tenant-a/prod/training-platform-assessment:1.2.3',
+    ],
+    {
+      'europe-west2-docker.pkg.dev/project-a/tenant/tenant-a/prod/api:1.2.3': {
+        manifest: { digest: 'sha256:resolved' },
+        image: { os: 'linux', architecture: 'amd64' },
+      },
+      'europe-west2-docker.pkg.dev/project-a/tenant/tenant-a/prod/training-platform-assessment:1.2.3': {
+        manifest: {
+          digest: 'sha256:chart',
+          mediaType: 'application/vnd.oci.image.manifest.v1+json',
+          config: { mediaType: 'application/vnd.cncf.helm.config.v1+json' },
+        },
+      },
+    },
+  );
+  assert.deepStrictEqual(mixedArtifacts.failures, []);
+  assert.deepStrictEqual(mixedArtifacts.warnings, [
+    'Skipping europe-west2-docker.pkg.dev/project-a/tenant/tenant-a/prod/training-platform-assessment:1.2.3; it is an OCI artifact, not a container image.',
+  ]);
+  assert.deepStrictEqual(
+    fs.readFileSync(mixedArtifacts.outputs['list-path'], 'utf8').trim(),
+    'europe-west2-docker.pkg.dev/project-a/tenant/tenant-a/prod/api:1.2.3\tlinux/amd64\tsha256:resolved',
+  );
+
+  const allArtifacts = await runPullScript(
+    ['europe-west2-docker.pkg.dev/project-a/tenant/tenant-a/prod/training-platform-assessment:1.2.3'],
+    {
+      'europe-west2-docker.pkg.dev/project-a/tenant/tenant-a/prod/training-platform-assessment:1.2.3': {
+        artifactType: 'application/vnd.cncf.helm.chart.content.v1.tar+gzip',
+        manifest: { digest: 'sha256:chart' },
+      },
+    },
+  );
+  assert.deepStrictEqual(allArtifacts.failures, [
+    'No container images found to scan after excluding non-image OCI artifacts.',
+  ]);
+  assert.deepStrictEqual(allArtifacts.warnings, [
+    'Skipping europe-west2-docker.pkg.dev/project-a/tenant/tenant-a/prod/training-platform-assessment:1.2.3; it is an OCI artifact, not a container image.',
+  ]);
+  assert.strictEqual(fs.readFileSync(allArtifacts.outputs['list-path'], 'utf8'), '');
+
+  const malformedImage = await runPullScript(
+    ['europe-west2-docker.pkg.dev/project-a/tenant/tenant-a/prod/api:1.2.3'],
+    {
+      'europe-west2-docker.pkg.dev/project-a/tenant/tenant-a/prod/api:1.2.3': {
+        manifest: { digest: 'sha256:resolved' },
+      },
+    },
+  );
+  assert.deepStrictEqual(malformedImage.failures, [
+    'Could not resolve platform/digest for europe-west2-docker.pkg.dev/project-a/tenant/tenant-a/prod/api:1.2.3.',
+  ]);
+  assert.deepStrictEqual(malformedImage.warnings, []);
 
   const multi = await runManifestScript({
     stage: 'extended-test',


### PR DESCRIPTION
## Summary
- skip non-image OCI artifacts, such as Helm charts, when preparing image scan targets
- warn for skipped artifacts instead of failing the whole scan when real images remain
- fail clearly if every resolved reference is a non-image artifact
- keep malformed container image metadata as a hard failure

## Tests
- node .github/scripts/tests/image-scan-manifest.test.js
- for test in .github/scripts/tests/*.test.js; do node "" || exit 1; done