### PR TITLE
Keep scanner helper sources outside app workspace

### DIFF
--- a/.github/workflows/internal-ci.yaml
+++ b/.github/workflows/internal-ci.yaml
@@ -96,6 +96,21 @@ jobs:
           node .github/scripts/tests/source-security-ignore-report.test.js
           node .github/scripts/tests/source-secret-redaction.test.js
 
+      - name: Test source security helpers stay outside app workspace
+        run: |
+          set -euo pipefail
+          python3 <<'PY'
+          from pathlib import Path
+
+          workflow = Path('.github/workflows/p2p-workflow-source-security-scan.yaml').read_text()
+          assert 'path: .p2p-workflow-src' in workflow
+          assert 'Move P2P workflow sources outside app workspace' in workflow
+          assert 'mv .p2p-workflow-src "$RUNNER_TEMP/p2p-workflow-src"' in workflow
+          assert 'P2P_SECURITY_IGNORE_HELPER: $' + '{{ runner.temp }}/p2p-workflow-src/.github/scripts/p2p-security-ignore.js' in workflow
+          assert "process.env.RUNNER_TEMP, 'p2p-workflow-src'" in workflow
+          assert 'github.workspace' not in workflow
+          PY
+
   test_image_scan:
     needs: [test_version]
     strategy:
@@ -189,6 +204,12 @@ jobs:
           assert 'PIPELINE_STAGE: $' + '{{ inputs.pipeline-stage }}' in workflow
           assert 'header: image-scan-findings-$' + '{{ inputs.pipeline-stage }}-$' + '{{ inputs.github_env || ' in workflow
           assert 'name: image-scan-reports-$' + '{{ inputs.pipeline-stage }}-$' + '{{ inputs.github_env || ' in workflow
+          assert 'path: .p2p-workflow-src' in workflow
+          assert 'Move P2P workflow sources outside app workspace' in workflow
+          assert 'mv .p2p-workflow-src "$RUNNER_TEMP/p2p-workflow-src"' in workflow
+          assert 'P2P_IMAGE_SCAN_HELPERS: $' + '{{ runner.temp }}/p2p-workflow-src/.github/scripts/image-scan-helpers.js' in workflow
+          assert 'P2P_IMAGE_SECURITY_REPORT: $' + '{{ runner.temp }}/p2p-workflow-src/.github/scripts/image-security-report.js' in workflow
+          assert 'github.workspace' not in workflow
           assert 'json-file:' in workflow
           assert 'value: $' + '{{ jobs.image-scan.outputs.json-file }}' in workflow
           assert 'json-file: $' + '{{ steps.report.outputs.json-file }}' in workflow

--- a/.github/workflows/p2p-workflow-image-scan.yaml
+++ b/.github/workflows/p2p-workflow-image-scan.yaml
@@ -103,6 +103,13 @@ jobs:
           ref: ${{ job.workflow_sha }}
           path: .p2p-workflow-src
 
+      - name: Move P2P workflow sources outside app workspace
+        shell: bash
+        run: |
+          set -euo pipefail
+          rm -rf "$RUNNER_TEMP/p2p-workflow-src"
+          mv .p2p-workflow-src "$RUNNER_TEMP/p2p-workflow-src"
+
       - name: Authenticate to Google Cloud
         id: auth
         if: ${{ inputs.dry-run == false }}
@@ -143,7 +150,7 @@ jobs:
           PIPELINE_STAGE: ${{ inputs.pipeline-stage }}
           WORKING_DIR: ${{ inputs.working-directory }}
           IMAGE_NAMES: ${{ inputs.image-names }}
-          P2P_IMAGE_SCAN_HELPERS: ${{ github.workspace }}/.p2p-workflow-src/.github/scripts/image-scan-helpers.js
+          P2P_IMAGE_SCAN_HELPERS: ${{ runner.temp }}/p2p-workflow-src/.github/scripts/image-scan-helpers.js
         with:
           script: |
             const { resolveImages } = require(process.env.P2P_IMAGE_SCAN_HELPERS);
@@ -155,7 +162,7 @@ jobs:
         uses: actions/github-script@v9
         env:
           IMAGE_REFS: ${{ steps.resolve-images.outputs.image-refs }}
-          P2P_IMAGE_SCAN_HELPERS: ${{ github.workspace }}/.p2p-workflow-src/.github/scripts/image-scan-helpers.js
+          P2P_IMAGE_SCAN_HELPERS: ${{ runner.temp }}/p2p-workflow-src/.github/scripts/image-scan-helpers.js
         with:
           script: |
             const { pullImages } = require(process.env.P2P_IMAGE_SCAN_HELPERS);
@@ -183,7 +190,7 @@ jobs:
         env:
           PULLED_LIST: ${{ steps.pull-images.outputs.list-path }}
           IGNORE_UNFIXED: ${{ inputs.ignore-unfixed }}
-          P2P_IMAGE_SCAN_HELPERS: ${{ github.workspace }}/.p2p-workflow-src/.github/scripts/image-scan-helpers.js
+          P2P_IMAGE_SCAN_HELPERS: ${{ runner.temp }}/p2p-workflow-src/.github/scripts/image-scan-helpers.js
         with:
           script: |
             const { scanImages } = require(process.env.P2P_IMAGE_SCAN_HELPERS);
@@ -195,8 +202,8 @@ jobs:
         uses: actions/github-script@v9
         env:
           PULLED_LIST: ${{ steps.pull-images.outputs.list-path }}
-          P2P_SECURITY_IGNORE_HELPER: ${{ github.workspace }}/.p2p-workflow-src/.github/scripts/p2p-security-ignore.js
-          P2P_IMAGE_SCAN_HELPERS: ${{ github.workspace }}/.p2p-workflow-src/.github/scripts/image-scan-helpers.js
+          P2P_SECURITY_IGNORE_HELPER: ${{ runner.temp }}/p2p-workflow-src/.github/scripts/p2p-security-ignore.js
+          P2P_IMAGE_SCAN_HELPERS: ${{ runner.temp }}/p2p-workflow-src/.github/scripts/image-scan-helpers.js
         with:
           script: |
             const { secretScanImages } = require(process.env.P2P_IMAGE_SCAN_HELPERS);
@@ -212,7 +219,7 @@ jobs:
           SECRET_REPORT_LIST: ${{ steps.secret-scan.outputs.report-list }}
           REPORT_ROOT: ${{ steps.scan.outputs.reports-dir }}
           SECRET_REPORT_ROOT: ${{ steps.secret-scan.outputs.reports-dir }}
-          P2P_IMAGE_SCAN_HELPERS: ${{ github.workspace }}/.p2p-workflow-src/.github/scripts/image-scan-helpers.js
+          P2P_IMAGE_SCAN_HELPERS: ${{ runner.temp }}/p2p-workflow-src/.github/scripts/image-scan-helpers.js
         with:
           script: |
             const { buildManifest } = require(process.env.P2P_IMAGE_SCAN_HELPERS);
@@ -230,8 +237,8 @@ jobs:
           GITHUB_ENV_INPUT: ${{ inputs.github_env }}
           VERSION: ${{ inputs.version }}
           ARTIFACT_DIR: ${{ steps.manifest.outputs.artifact-dir }}
-          P2P_SECURITY_IGNORE_HELPER: ${{ github.workspace }}/.p2p-workflow-src/.github/scripts/p2p-security-ignore.js
-          P2P_IMAGE_SECURITY_REPORT: ${{ github.workspace }}/.p2p-workflow-src/.github/scripts/image-security-report.js
+          P2P_SECURITY_IGNORE_HELPER: ${{ runner.temp }}/p2p-workflow-src/.github/scripts/p2p-security-ignore.js
+          P2P_IMAGE_SECURITY_REPORT: ${{ runner.temp }}/p2p-workflow-src/.github/scripts/image-security-report.js
         with:
           script: |
             const { buildImageSecurityReport } = require(process.env.P2P_IMAGE_SECURITY_REPORT);

--- a/.github/workflows/p2p-workflow-source-security-scan.yaml
+++ b/.github/workflows/p2p-workflow-source-security-scan.yaml
@@ -120,6 +120,14 @@ jobs:
           ref: ${{ job.workflow_sha }}
           path: .p2p-workflow-src
 
+      - name: Move P2P workflow sources outside app workspace
+        if: ${{ always() && inputs.dry-run == false }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          rm -rf "$RUNNER_TEMP/p2p-workflow-src"
+          mv .p2p-workflow-src "$RUNNER_TEMP/p2p-workflow-src"
+
       - id: redact
         name: Build redacted secret findings
         if: ${{ always() && inputs.dry-run == false }}
@@ -131,7 +139,7 @@ jobs:
         run: |
           set -euo pipefail
           redacted="$RUNNER_TEMP/findings.ndjson"
-          node .p2p-workflow-src/.github/scripts/source-secret-redact.js "$FINDINGS" "$redacted"
+          node "$RUNNER_TEMP/p2p-workflow-src/.github/scripts/source-secret-redact.js" "$FINDINGS" "$redacted"
           echo "redacted_file=$redacted" >> "$GITHUB_OUTPUT"
 
       - name: Upload redacted secret findings
@@ -217,6 +225,13 @@ jobs:
           ref: ${{ job.workflow_sha }}
           path: .p2p-workflow-src
 
+      - name: Move P2P workflow sources outside app workspace
+        shell: bash
+        run: |
+          set -euo pipefail
+          rm -rf "$RUNNER_TEMP/p2p-workflow-src"
+          mv .p2p-workflow-src "$RUNNER_TEMP/p2p-workflow-src"
+
       - name: Download secret findings
         if: ${{ inputs.dry-run == false }}
         continue-on-error: true
@@ -244,11 +259,11 @@ jobs:
           ROOT: ${{ runner.temp }}/source-security
           SECRET_SCAN_RESULT: ${{ needs.secret-scan.result }}
           SCA_SCAN_RESULT: ${{ needs.sca-scan.result }}
-          P2P_SECURITY_IGNORE_HELPER: ${{ github.workspace }}/.p2p-workflow-src/.github/scripts/p2p-security-ignore.js
+          P2P_SECURITY_IGNORE_HELPER: ${{ runner.temp }}/p2p-workflow-src/.github/scripts/p2p-security-ignore.js
         with:
           script: |
             const path = require('path');
-            const reportModule = path.join(process.env.GITHUB_WORKSPACE, '.p2p-workflow-src', '.github', 'scripts', 'source-security-report.js');
+            const reportModule = path.join(process.env.RUNNER_TEMP, 'p2p-workflow-src', '.github', 'scripts', 'source-security-report.js');
             const { buildSourceSecurityReport } = require(reportModule);
             await buildSourceSecurityReport({ core });
 


### PR DESCRIPTION
## Summary
- checkout P2P scanner workflow sources under `${{ runner.temp }}/p2p-workflow-src` instead of the app workspace
- update image and source security scanner helper paths to load from `RUNNER_TEMP`
- add CI assertions that scanner helpers stay outside app package scope