### PR TITLE
Rename security workflow jobs

### DIFF
--- a/.github/scripts/tests/image-security-ignore-report.test.js
+++ b/.github/scripts/tests/image-security-ignore-report.test.js
@@ -341,7 +341,7 @@ function assertWorkflowEnforcesScanStatus(workflowPath, outputName) {
 
 function assertImagePolicyFailsOnAnyFindingButOnlyBlocksOnBlockingFindings(workflowPath) {
   const workflow = fs.readFileSync(workflowPath, 'utf8');
-  assert(workflow.includes("continue-on-error: ${{ inputs.blocking-severity == 'off' || (needs.image-scan.outputs.blocking-count == '0' && needs.image-scan.outputs.secret-blocking-count == '0') }}"));
+  assert(workflow.includes("continue-on-error: ${{ inputs.blocking-severity == 'off' || (needs.security-image-scan.outputs.blocking-count == '0' && needs.security-image-scan.outputs.secret-blocking-count == '0') }}"));
   assert(workflow.includes('elif [ "${TOTAL:-0}" -gt 0 ] || [ "${SECRET_TOTAL:-0}" -gt 0 ]; then'));
   assert(workflow.includes('Security finding(s) detected below blocking-severity=${BLOCKING_SEVERITY}; this policy job is allowed to fail without failing the workflow.'));
 }
@@ -879,9 +879,9 @@ async function runZeroScanTargetReport() {
   assert(!offMode.summary.includes('Accepted off-mode image secret.'));
   const imageStatusSteps = readStatusStepNames(path.resolve(__dirname, '../../workflows/p2p-workflow-image-scan.yaml'));
   assert.deepStrictEqual(imageStatusSteps, [
-    '      - name: "Output security risk: ${{ needs.image-scan.outputs.security-risk || \'unknown\' }}; scan: ${{ needs.image-scan.outputs.scan-status || \'failed\' }}"',
+    '      - name: "Output security risk: ${{ needs.security-image-scan.outputs.security-risk || \'unknown\' }}; scan: ${{ needs.security-image-scan.outputs.scan-status || \'failed\' }}"',
   ]);
-  assertWorkflowEnforcesScanStatus(path.resolve(__dirname, '../../workflows/p2p-workflow-image-scan.yaml'), 'image-scan');
+  assertWorkflowEnforcesScanStatus(path.resolve(__dirname, '../../workflows/p2p-workflow-image-scan.yaml'), 'security-image-scan');
   assertImagePolicyFailsOnAnyFindingButOnlyBlocksOnBlockingFindings(path.resolve(__dirname, '../../workflows/p2p-workflow-image-scan.yaml'));
   assertLatestImageLookupDoesNotRequireCallerCheckout(path.resolve(__dirname, '../../workflows/p2p-get-latest-image.yaml'));
   console.log('image security ignore report fixtures passed');

--- a/.github/scripts/tests/source-security-ignore-report.test.js
+++ b/.github/scripts/tests/source-security-ignore-report.test.js
@@ -263,7 +263,7 @@ function assertWorkflowEnforcesScanStatus(workflowPath, outputName) {
 
 function assertSourcePolicyFailsOnAnyFindingButOnlyBlocksOnBlockingFindings(workflowPath) {
   const workflow = fs.readFileSync(workflowPath, 'utf8');
-  assert(workflow.includes("continue-on-error: ${{ inputs.blocking-severity == 'off' || (needs.report.outputs.vulnerability-blocking == '0' && needs.report.outputs.secret-blocking == '0') }}"));
+  assert(workflow.includes("continue-on-error: ${{ inputs.blocking-severity == 'off' || (needs.security-source-report.outputs.vulnerability-blocking == '0' && needs.security-source-report.outputs.secret-blocking == '0') }}"));
   assert(workflow.includes('elif [ "${VULN_TOTAL:-0}" -gt 0 ] || [ "${SECRET_TOTAL:-0}" -gt 0 ]; then'));
   assert(workflow.includes('Security finding(s) detected below blocking-severity=${BLOCKING_SEVERITY}; this policy job is allowed to fail without failing the workflow.'));
 }
@@ -926,9 +926,9 @@ async function runReportWithMissingTruffleHogOutput() {
   assert.strictEqual(scannerWarning.outputs['scan-status'], 'failed');
   const sourceStatusSteps = readStatusStepNames(path.resolve(__dirname, '../../workflows/p2p-workflow-source-security-scan.yaml'));
   assert.deepStrictEqual(sourceStatusSteps, [
-    '      - name: "Output security risk: ${{ needs.report.outputs.security-risk || \'unknown\' }}; scan: ${{ needs.report.outputs.scan-status || \'failed\' }}"',
+    '      - name: "Output security risk: ${{ needs.security-source-report.outputs.security-risk || \'unknown\' }}; scan: ${{ needs.security-source-report.outputs.scan-status || \'failed\' }}"',
   ]);
-  assertWorkflowEnforcesScanStatus(path.resolve(__dirname, '../../workflows/p2p-workflow-source-security-scan.yaml'), 'report');
+  assertWorkflowEnforcesScanStatus(path.resolve(__dirname, '../../workflows/p2p-workflow-source-security-scan.yaml'), 'security-source-report');
   assertSourcePolicyFailsOnAnyFindingButOnlyBlocksOnBlockingFindings(path.resolve(__dirname, '../../workflows/p2p-workflow-source-security-scan.yaml'));
   assertSourceTrivyReportsUnknownSeverity(path.resolve(__dirname, '../../workflows/p2p-workflow-source-security-scan.yaml'));
   for (const mode of ['missing', 'empty', 'invalid']) {

--- a/.github/workflows/internal-ci.yaml
+++ b/.github/workflows/internal-ci.yaml
@@ -107,7 +107,7 @@ jobs:
           assert 'Move P2P workflow sources outside app workspace' in workflow
           assert 'mv .p2p-workflow-src "$RUNNER_TEMP/p2p-workflow-src"' in workflow
           assert 'tenant-name:' in workflow
-          assert 'header: source-security-scan-findings-$' + '{{ inputs.app-name || inputs.tenant-name || vars.TENANT_NAME }}' in workflow
+          assert 'header: security-source-scan-findings-$' + '{{ inputs.app-name || inputs.tenant-name || vars.TENANT_NAME }}' in workflow
           assert 'P2P_SECURITY_IGNORE_HELPER: $' + '{{ runner.temp }}/p2p-workflow-src/.github/scripts/p2p-security-ignore.js' in workflow
           assert "process.env.RUNNER_TEMP, 'p2p-workflow-src'" in workflow
           assert 'github.workspace' not in workflow
@@ -210,11 +210,11 @@ jobs:
           assert 'name: get-latest-image ($' + '{{ inputs.registry-path }}, $' + '{{ inputs.github_env }})' in latest_workflow
 
           workflow = Path('.github/workflows/p2p-workflow-image-scan.yaml').read_text()
-          assert "name: image-scan ($" + "{{ inputs.github_env != '' && format('{0}, {1}', inputs.pipeline-stage, inputs.github_env) || inputs.pipeline-stage }})" in workflow
-          assert 'name: ' + "'image-scan ($" + '{{ inputs.github_env }})' not in workflow
+          assert "name: security-image-scan ($" + "{{ inputs.github_env != '' && format('{0}, {1}', inputs.pipeline-stage, inputs.github_env) || inputs.pipeline-stage }})" in workflow
+          assert 'name: ' + "'security-image-scan ($" + '{{ inputs.github_env }})' not in workflow
           assert 'PIPELINE_STAGE: $' + '{{ inputs.pipeline-stage }}' in workflow
-          assert 'header: image-scan-findings-$' + '{{ inputs.app-name || inputs.tenant-name || vars.TENANT_NAME }}-$' + '{{ inputs.pipeline-stage }}-$' + '{{ inputs.github_env || ' in workflow
-          assert 'name: image-scan-reports-$' + '{{ inputs.pipeline-stage }}-$' + '{{ inputs.github_env || ' in workflow
+          assert 'header: security-image-scan-findings-$' + '{{ inputs.app-name || inputs.tenant-name || vars.TENANT_NAME }}-$' + '{{ inputs.pipeline-stage }}-$' + '{{ inputs.github_env || ' in workflow
+          assert 'name: security-image-scan-reports-$' + '{{ inputs.pipeline-stage }}-$' + '{{ inputs.github_env || ' in workflow
           assert 'path: .p2p-workflow-src' in workflow
           assert 'Move P2P workflow sources outside app workspace' in workflow
           assert 'mv .p2p-workflow-src "$RUNNER_TEMP/p2p-workflow-src"' in workflow
@@ -222,7 +222,7 @@ jobs:
           assert 'P2P_IMAGE_SECURITY_REPORT: $' + '{{ runner.temp }}/p2p-workflow-src/.github/scripts/image-security-report.js' in workflow
           assert 'github.workspace' not in workflow
           assert 'json-file:' in workflow
-          assert 'value: $' + '{{ jobs.image-scan.outputs.json-file }}' in workflow
+          assert 'value: $' + '{{ jobs.security-image-scan.outputs.json-file }}' in workflow
           assert 'json-file: $' + '{{ steps.report.outputs.json-file }}' in workflow
 
           report_module = Path('.github/scripts/image-security-report.js').read_text()
@@ -244,7 +244,7 @@ jobs:
           upload_block = []
           in_upload = False
           for line in workflow.read_text().splitlines():
-              if line.startswith('      - name: Upload image-scan reports'):
+              if line.startswith('      - name: Upload security-image-scan reports'):
                   in_upload = True
               elif in_upload and line.startswith('      - name: '):
                   break
@@ -255,10 +255,10 @@ jobs:
           upload_text = '\n'.join(upload_block)
           for forbidden in ('always()', 'reports-dir', 'reports.txt', 'if-no-files-found: ignore'):
               if forbidden in upload_text:
-                  raise SystemExit(f'Upload image-scan reports must not contain {forbidden}')
+                  raise SystemExit(f'Upload security-image-scan reports must not contain {forbidden}')
           for required in ('steps.manifest.outputs.artifact-dir', 'if-no-files-found: error'):
               if required not in upload_text:
-                  raise SystemExit(f'Upload image-scan reports is missing {required}')
+                  raise SystemExit(f'Upload security-image-scan reports is missing {required}')
           PY
 
           node .github/scripts/tests/image-scan-manifest.test.js

--- a/.github/workflows/p2p-workflow-extended-test.yaml
+++ b/.github/workflows/p2p-workflow-extended-test.yaml
@@ -26,7 +26,7 @@ on:
         default: false
       security-scan-blocking-severity:
         description: |
-          Minimum severity that blocks the workflow for image-scan findings:
+          Minimum severity that blocks the workflow for security-image-scan findings:
           off, low, medium, high, or critical.
         required: false
         type: string
@@ -95,7 +95,7 @@ jobs:
       skip-subnamespaces-create: ${{ inputs.skip-subnamespaces-create }}
       artifacts: ${{ inputs.artifacts }}
 
-  image-scan:
+  security-image-scan:
     uses: ./.github/workflows/p2p-workflow-image-scan.yaml
     if: success() && (github.ref == inputs.main-branch)
     permissions:
@@ -124,7 +124,7 @@ jobs:
   promote:
     uses: ./.github/workflows/p2p-promote-image.yaml
     if: success() && (github.ref == inputs.main-branch)
-    needs: [run-tests, image-scan]
+    needs: [run-tests, security-image-scan]
     secrets:
       env_vars: ${{ secrets.env_vars }}
     strategy:
@@ -143,7 +143,7 @@ jobs:
       checkout-version: ${{ inputs.version-prefix }}${{ inputs.version }}
 
   notify-failure:
-    needs: [run-tests, image-scan, promote]
+    needs: [run-tests, security-image-scan, promote]
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     if: always() && github.ref == inputs.main-branch && contains(needs.*.result, 'failure')

--- a/.github/workflows/p2p-workflow-fastfeedback.yaml
+++ b/.github/workflows/p2p-workflow-fastfeedback.yaml
@@ -67,8 +67,8 @@ on:
         default: ''
       security-scan-blocking-severity:
         description: |
-          Minimum severity that blocks the workflow for source-security-scan
-          and image-scan findings: off, low, medium, high, or critical.
+          Minimum severity that blocks the workflow for security-source-scan
+          and security-image-scan findings: off, low, medium, high, or critical.
         required: false
         type: string
         default: off
@@ -100,7 +100,7 @@ jobs:
       skip-subnamespaces-create: ${{ inputs.skip-subnamespaces-create }}
       artifacts: ${{ inputs.artifacts }}
 
-  source-security-scan:
+  security-source-scan:
     uses: ./.github/workflows/p2p-workflow-source-security-scan.yaml
     with:
       secret-scan-scope: changes
@@ -111,7 +111,7 @@ jobs:
       checkout-version: ${{ inputs.checkout-version }}
       timeout-minutes: 10
 
-  image-scan:
+  security-image-scan:
     needs: [build]
     uses: ./.github/workflows/p2p-workflow-image-scan.yaml
     secrets:
@@ -212,7 +212,7 @@ jobs:
 
   promote:
     name: promote
-    needs: [integration-test, image-scan, source-security-scan]
+    needs: [integration-test, security-image-scan, security-source-scan]
     if: success() && ( github.ref == inputs.main-branch || github.ref_type == 'tag' )
     secrets:
       env_vars: ${{ secrets.env_vars }}
@@ -233,7 +233,7 @@ jobs:
       working-directory: ${{ inputs.working-directory }}
 
   notify-failure:
-    needs: [build, source-security-scan, image-scan, functional-test, nft-test, integration-test, promote]
+    needs: [build, security-source-scan, security-image-scan, functional-test, nft-test, integration-test, promote]
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     if: always() && github.ref == inputs.main-branch && contains(needs.*.result, 'failure')

--- a/.github/workflows/p2p-workflow-image-scan.yaml
+++ b/.github/workflows/p2p-workflow-image-scan.yaml
@@ -66,15 +66,15 @@ on:
         default: 20
     outputs:
       json-file:
-        value: ${{ jobs.image-scan.outputs.json-file }}
+        value: ${{ jobs.security-image-scan.outputs.json-file }}
       security-risk:
-        value: ${{ jobs.image-scan.outputs.security-risk }}
+        value: ${{ jobs.security-image-scan.outputs.security-risk }}
       scan-status:
-        value: ${{ jobs.image-scan.outputs.scan-status }}
+        value: ${{ jobs.security-image-scan.outputs.scan-status }}
 
 jobs:
-  image-scan:
-    name: image-scan (${{ inputs.github_env != '' && format('{0}, {1}', inputs.pipeline-stage, inputs.github_env) || inputs.pipeline-stage }})
+  security-image-scan:
+    name: security-image-scan (${{ inputs.github_env != '' && format('{0}, {1}', inputs.pipeline-stage, inputs.github_env) || inputs.pipeline-stage }})
     runs-on: ubuntu-24.04
     environment: ${{ inputs.github_env }}
     timeout-minutes: ${{ inputs.timeout-minutes }}
@@ -200,7 +200,7 @@ jobs:
             const { scanImages } = require(process.env.P2P_IMAGE_SCAN_HELPERS);
             await scanImages({ core });
 
-      - id: secret-scan
+      - id: security-secret-scan
         name: Scan images for secrets
         if: ${{ inputs.dry-run == false }}
         uses: actions/github-script@v9
@@ -220,9 +220,9 @@ jobs:
         env:
           PIPELINE_STAGE: ${{ inputs.pipeline-stage }}
           REPORT_LIST: ${{ steps.scan.outputs.report-list }}
-          SECRET_REPORT_LIST: ${{ steps.secret-scan.outputs.report-list }}
+          SECRET_REPORT_LIST: ${{ steps.security-secret-scan.outputs.report-list }}
           REPORT_ROOT: ${{ steps.scan.outputs.reports-dir }}
-          SECRET_REPORT_ROOT: ${{ steps.secret-scan.outputs.reports-dir }}
+          SECRET_REPORT_ROOT: ${{ steps.security-secret-scan.outputs.reports-dir }}
           SCAN_TARGET_COUNT: ${{ steps.pull-images.outputs.scan-target-count }}
           P2P_IMAGE_SCAN_HELPERS: ${{ runner.temp }}/p2p-workflow-src/.github/scripts/image-scan-helpers.js
         with:
@@ -236,7 +236,7 @@ jobs:
         uses: actions/github-script@v9
         env:
           REPORT_LIST: ${{ steps.scan.outputs.report-list }}
-          SECRET_REPORT_LIST: ${{ steps.secret-scan.outputs.report-list }}
+          SECRET_REPORT_LIST: ${{ steps.security-secret-scan.outputs.report-list }}
           BLOCKING_SEVERITY: ${{ inputs.blocking-severity }}
           PIPELINE_STAGE: ${{ inputs.pipeline-stage }}
           GITHUB_ENV_INPUT: ${{ inputs.github_env }}
@@ -255,30 +255,30 @@ jobs:
         continue-on-error: true
         uses: marocchino/sticky-pull-request-comment@v3
         with:
-          header: image-scan-findings-${{ inputs.app-name || inputs.tenant-name || vars.TENANT_NAME }}-${{ inputs.pipeline-stage }}-${{ inputs.github_env || 'local' }}
+          header: security-image-scan-findings-${{ inputs.app-name || inputs.tenant-name || vars.TENANT_NAME }}-${{ inputs.pipeline-stage }}-${{ inputs.github_env || 'local' }}
           path: ${{ steps.report.outputs.comment-path }}
           recreate: true
 
-      - name: Upload image-scan reports
+      - name: Upload security-image-scan reports
         if: ${{ inputs.dry-run == false && steps.manifest.outputs.artifact-dir != '' }}
         uses: actions/upload-artifact@v7
         with:
-          name: image-scan-reports-${{ inputs.pipeline-stage }}-${{ inputs.github_env || 'local' }}
+          name: security-image-scan-reports-${{ inputs.pipeline-stage }}-${{ inputs.github_env || 'local' }}
           path: ${{ steps.manifest.outputs.artifact-dir }}
           if-no-files-found: error
           retention-days: 30
 
-  scan-status-policy:
-    name: image-scan-status-policy (${{ inputs.github_env != '' && format('{0}, {1}', inputs.pipeline-stage, inputs.github_env) || inputs.pipeline-stage }})
+  security-image-scan-status-policy:
+    name: security-image-scan-status-policy (${{ inputs.github_env != '' && format('{0}, {1}', inputs.pipeline-stage, inputs.github_env) || inputs.pipeline-stage }})
     runs-on: ubuntu-24.04
-    needs: [image-scan]
+    needs: [security-image-scan]
     if: ${{ always() && inputs.dry-run == false }}
     timeout-minutes: 1
     steps:
       - name: Enforce scanner execution status
         shell: bash
         env:
-          SCAN_STATUS: ${{ needs.image-scan.outputs.scan-status || 'failed' }}
+          SCAN_STATUS: ${{ needs.security-image-scan.outputs.scan-status || 'failed' }}
         run: |
           set -euo pipefail
           if [ "${SCAN_STATUS}" != "ok" ]; then
@@ -286,25 +286,25 @@ jobs:
             exit 1
           fi
 
-  policy:
-    name: image-scan-policy (${{ inputs.github_env != '' && format('{0}, {1}', inputs.pipeline-stage, inputs.github_env) || inputs.pipeline-stage }})
+  security-image-policy:
+    name: security-image-policy (${{ inputs.github_env != '' && format('{0}, {1}', inputs.pipeline-stage, inputs.github_env) || inputs.pipeline-stage }})
     runs-on: ubuntu-24.04
-    needs: [image-scan]
+    needs: [security-image-scan]
     if: ${{ always() && inputs.dry-run == false }}
-    continue-on-error: ${{ inputs.blocking-severity == 'off' || (needs.image-scan.outputs.blocking-count == '0' && needs.image-scan.outputs.secret-blocking-count == '0') }}
+    continue-on-error: ${{ inputs.blocking-severity == 'off' || (needs.security-image-scan.outputs.blocking-count == '0' && needs.security-image-scan.outputs.secret-blocking-count == '0') }}
     timeout-minutes: 1
     steps:
-      - name: "Output security risk: ${{ needs.image-scan.outputs.security-risk || 'unknown' }}; scan: ${{ needs.image-scan.outputs.scan-status || 'failed' }}"
+      - name: "Output security risk: ${{ needs.security-image-scan.outputs.security-risk || 'unknown' }}; scan: ${{ needs.security-image-scan.outputs.scan-status || 'failed' }}"
         run: ':'
 
       - name: Enforce policy
         shell: bash
         env:
           BLOCKING_SEVERITY: ${{ inputs.blocking-severity }}
-          BLOCKING: ${{ needs.image-scan.outputs.blocking-count }}
-          TOTAL: ${{ needs.image-scan.outputs.total-count }}
-          SECRET_BLOCKING: ${{ needs.image-scan.outputs.secret-blocking-count }}
-          SECRET_TOTAL: ${{ needs.image-scan.outputs.secret-total-count }}
+          BLOCKING: ${{ needs.security-image-scan.outputs.blocking-count }}
+          TOTAL: ${{ needs.security-image-scan.outputs.total-count }}
+          SECRET_BLOCKING: ${{ needs.security-image-scan.outputs.secret-blocking-count }}
+          SECRET_TOTAL: ${{ needs.security-image-scan.outputs.secret-total-count }}
         run: |
           set -euo pipefail
           case "${BLOCKING_SEVERITY}" in

--- a/.github/workflows/p2p-workflow-prod.yaml
+++ b/.github/workflows/p2p-workflow-prod.yaml
@@ -55,7 +55,7 @@ on:
         default: false
       security-scan-blocking-severity:
         description: |
-          Minimum severity that blocks the workflow for image-scan findings:
+          Minimum severity that blocks the workflow for security-image-scan findings:
           off, low, medium, high, or critical.
         required: false
         type: string
@@ -79,7 +79,7 @@ jobs:
             exit 1
           fi
 
-  image-scan:
+  security-image-scan:
     needs: [validate-version]
     if: success() && github.ref == inputs.main-branch
     uses: ./.github/workflows/p2p-workflow-image-scan.yaml
@@ -108,7 +108,7 @@ jobs:
 
   prod-deploy:
     name: prod-deploy
-    needs: [image-scan]
+    needs: [security-image-scan]
     if: success() && github.ref == inputs.main-branch
     uses: ./.github/workflows/p2p-execute-command.yaml
     secrets:
@@ -133,7 +133,7 @@ jobs:
       skip-subnamespaces-create: ${{ inputs.skip-subnamespaces-create }}
 
   notify-failure:
-    needs: [validate-version, image-scan, prod-deploy]
+    needs: [validate-version, security-image-scan, prod-deploy]
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     if: always() && github.ref == inputs.main-branch && contains(needs.*.result, 'failure')

--- a/.github/workflows/p2p-workflow-security-image-scan-stage.yaml
+++ b/.github/workflows/p2p-workflow-security-image-scan-stage.yaml
@@ -52,14 +52,14 @@ on:
         default: ''
       security-scan-blocking-severity:
         description: |
-          Minimum severity that blocks the workflow for image-scan findings:
+          Minimum severity that blocks the workflow for security-image-scan findings:
           off, low, medium, high, or critical.
         required: false
         type: string
         default: 'off'
 
 jobs:
-  discover-version:
+  security-discover-version:
     uses: ./.github/workflows/p2p-get-latest-image.yaml
     permissions:
       contents: read
@@ -75,9 +75,9 @@ jobs:
       github_env: ${{ inputs.github_env }}
       working-directory: ${{ inputs.working-directory }}
 
-  image-scan:
-    needs: [discover-version]
-    if: needs.discover-version.outputs.found == 'true'
+  security-image-scan:
+    needs: [security-discover-version]
+    if: needs.security-discover-version.outputs.found == 'true'
     uses: ./.github/workflows/p2p-workflow-image-scan.yaml
     permissions:
       contents: read
@@ -92,7 +92,7 @@ jobs:
       github_env: ${{ inputs.github_env }}
       tenant-name: ${{ inputs.tenant-name }}
       app-name: ${{ inputs.app-name }}
-      version: ${{ needs.discover-version.outputs.version }}
+      version: ${{ needs.security-discover-version.outputs.version }}
       region: ${{ inputs.region }}
       working-directory: ${{ inputs.working-directory }}
       image-names: ${{ inputs.image-names }}

--- a/.github/workflows/p2p-workflow-security-scan.yaml
+++ b/.github/workflows/p2p-workflow-security-scan.yaml
@@ -22,7 +22,7 @@ on:
         description: |
           Newline- or comma-separated list of image names. The first entry is
           used as the version-lookup anchor for each stage, and the full list
-          is passed to image-scan. If empty, image-scan falls back to repository
+          is passed to security-image-scan. If empty, security-image-scan falls back to repository
           discovery.
         required: false
         type: string
@@ -45,8 +45,8 @@ on:
         default: ''
       security-scan-blocking-severity:
         description: |
-          Minimum severity that blocks the workflow for source-security-scan
-          and image-scan findings: off, low, medium, high, or critical.
+          Minimum severity that blocks the workflow for security-source-scan
+          and security-image-scan findings: off, low, medium, high, or critical.
         required: false
         type: string
         default: 'off'
@@ -56,7 +56,7 @@ on:
         default: 30
 
 jobs:
-  source-security-scan:
+  security-source-scan:
     uses: ./.github/workflows/p2p-workflow-source-security-scan.yaml
     with:
       secret-scan-scope: full-history
@@ -70,8 +70,8 @@ jobs:
   # Resolve a single anchor image used to look up the latest version per
   # stage. All p2p images in a release share the same version, so any image
   # works.
-  resolve-anchor-image:
-    name: resolve-anchor-image
+  security-resolve-anchor-image:
+    name: security-resolve-anchor-image
     runs-on: ubuntu-24.04
     outputs:
       image-name: ${{ steps.pick.outputs.image-name }}
@@ -100,8 +100,8 @@ jobs:
           echo "image-name=$anchor" >> "$GITHUB_OUTPUT"
           echo "Anchor image for version discovery: $anchor"
 
-  image-scan-fast-feedback:
-    needs: [resolve-anchor-image]
+  security-image-scan-fast-feedback:
+    needs: [security-resolve-anchor-image]
     uses: ./.github/workflows/p2p-workflow-security-image-scan-stage.yaml
     permissions:
       contents: read
@@ -119,7 +119,7 @@ jobs:
       pipeline-stage: fast-feedback
       tenant-name: ${{ inputs.tenant-name }}
       app-name: ${{ inputs.app-name }}
-      image-name: ${{ needs.resolve-anchor-image.outputs.image-name }}
+      image-name: ${{ needs.security-resolve-anchor-image.outputs.image-name }}
       image-names: ${{ inputs.image-names }}
       region: ${{ inputs.region }}
       github_env: ${{ matrix.deploy_env }}
@@ -128,8 +128,8 @@ jobs:
       checkout-version: ${{ inputs.checkout-version }}
       security-scan-blocking-severity: ${{ inputs.security-scan-blocking-severity }}
 
-  image-scan-extended-test:
-    needs: [resolve-anchor-image]
+  security-image-scan-extended-test:
+    needs: [security-resolve-anchor-image]
     uses: ./.github/workflows/p2p-workflow-security-image-scan-stage.yaml
     permissions:
       contents: read
@@ -147,7 +147,7 @@ jobs:
       pipeline-stage: extended-test
       tenant-name: ${{ inputs.tenant-name }}
       app-name: ${{ inputs.app-name }}
-      image-name: ${{ needs.resolve-anchor-image.outputs.image-name }}
+      image-name: ${{ needs.security-resolve-anchor-image.outputs.image-name }}
       image-names: ${{ inputs.image-names }}
       region: ${{ inputs.region }}
       github_env: ${{ matrix.deploy_env }}
@@ -156,8 +156,8 @@ jobs:
       checkout-version: ${{ inputs.checkout-version }}
       security-scan-blocking-severity: ${{ inputs.security-scan-blocking-severity }}
 
-  image-scan-prod:
-    needs: [resolve-anchor-image]
+  security-image-scan-prod:
+    needs: [security-resolve-anchor-image]
     uses: ./.github/workflows/p2p-workflow-security-image-scan-stage.yaml
     permissions:
       contents: read
@@ -175,7 +175,7 @@ jobs:
       pipeline-stage: prod
       tenant-name: ${{ inputs.tenant-name }}
       app-name: ${{ inputs.app-name }}
-      image-name: ${{ needs.resolve-anchor-image.outputs.image-name }}
+      image-name: ${{ needs.security-resolve-anchor-image.outputs.image-name }}
       image-names: ${{ inputs.image-names }}
       region: ${{ inputs.region }}
       github_env: ${{ matrix.deploy_env }}

--- a/.github/workflows/p2p-workflow-source-security-scan.yaml
+++ b/.github/workflows/p2p-workflow-source-security-scan.yaml
@@ -34,27 +34,27 @@ on:
         default: 30
     outputs:
       report-file:
-        value: ${{ jobs.report.outputs.report-file }}
+        value: ${{ jobs.security-source-report.outputs.report-file }}
       json-file:
-        value: ${{ jobs.report.outputs.json-file }}
+        value: ${{ jobs.security-source-report.outputs.json-file }}
       vulnerability-total:
-        value: ${{ jobs.report.outputs.vulnerability-total }}
+        value: ${{ jobs.security-source-report.outputs.vulnerability-total }}
       vulnerability-blocking:
-        value: ${{ jobs.report.outputs.vulnerability-blocking }}
+        value: ${{ jobs.security-source-report.outputs.vulnerability-blocking }}
       license-total:
-        value: ${{ jobs.report.outputs.license-total }}
+        value: ${{ jobs.security-source-report.outputs.license-total }}
       secret-total:
-        value: ${{ jobs.report.outputs.secret-total }}
+        value: ${{ jobs.security-source-report.outputs.secret-total }}
       secret-blocking:
-        value: ${{ jobs.report.outputs.secret-blocking }}
+        value: ${{ jobs.security-source-report.outputs.secret-blocking }}
       security-risk:
-        value: ${{ jobs.report.outputs.security-risk }}
+        value: ${{ jobs.security-source-report.outputs.security-risk }}
       scan-status:
-        value: ${{ jobs.report.outputs.scan-status }}
+        value: ${{ jobs.security-source-report.outputs.scan-status }}
 
 jobs:
-  secret-scan:
-    name: secret-scan
+  security-secret-scan:
+    name: security-secret-scan
     runs-on: ubuntu-24.04
     timeout-minutes: ${{ inputs.timeout-minutes }}
     outputs:
@@ -154,13 +154,13 @@ jobs:
         if: ${{ always() && inputs.dry-run == false }}
         uses: actions/upload-artifact@v7
         with:
-          name: source-security-internal-secret-findings
+          name: security-source-internal-secret-findings
           path: ${{ steps.redact.outputs.redacted_file }}
           if-no-files-found: warn
           retention-days: 1
 
-  sca-scan:
-    name: sca-scan
+  security-sca-scan:
+    name: security-sca-scan
     runs-on: ubuntu-24.04
     timeout-minutes: ${{ inputs.timeout-minutes }}
     steps:
@@ -200,15 +200,15 @@ jobs:
         if: ${{ always() && inputs.dry-run == false }}
         uses: actions/upload-artifact@v7
         with:
-          name: source-security-internal-trivy-findings
+          name: security-source-internal-trivy-findings
           path: ${{ steps.scan.outputs.trivy_file }}
           if-no-files-found: warn
           retention-days: 1
 
-  report:
-    name: source-security-report
+  security-source-report:
+    name: security-source-report
     runs-on: ubuntu-24.04
-    needs: [secret-scan, sca-scan]
+    needs: [security-secret-scan, security-sca-scan]
     if: always()
     outputs:
       report-file: ${{ steps.report.outputs.report-file }}
@@ -245,7 +245,7 @@ jobs:
         continue-on-error: true
         uses: actions/download-artifact@v8
         with:
-          name: source-security-internal-secret-findings
+          name: security-source-internal-secret-findings
           path: ${{ runner.temp }}/source-security/trufflehog
 
       - name: Download Trivy findings
@@ -253,7 +253,7 @@ jobs:
         continue-on-error: true
         uses: actions/download-artifact@v8
         with:
-          name: source-security-internal-trivy-findings
+          name: security-source-internal-trivy-findings
           path: ${{ runner.temp }}/source-security/trivy
 
       - id: report
@@ -261,12 +261,12 @@ jobs:
         uses: actions/github-script@v9
         env:
           SCOPE: ${{ inputs.secret-scan-scope }}
-          BASE: ${{ needs.secret-scan.outputs.base }}
+          BASE: ${{ needs.security-secret-scan.outputs.base }}
           BLOCKING_SEVERITY: ${{ inputs.blocking-severity }}
           DRY_RUN: ${{ inputs.dry-run }}
           ROOT: ${{ runner.temp }}/source-security
-          SECRET_SCAN_RESULT: ${{ needs.secret-scan.result }}
-          SCA_SCAN_RESULT: ${{ needs.sca-scan.result }}
+          SECRET_SCAN_RESULT: ${{ needs.security-secret-scan.result }}
+          SCA_SCAN_RESULT: ${{ needs.security-sca-scan.result }}
           P2P_SECURITY_IGNORE_HELPER: ${{ runner.temp }}/p2p-workflow-src/.github/scripts/p2p-security-ignore.js
         with:
           script: |
@@ -280,7 +280,7 @@ jobs:
         continue-on-error: true
         uses: marocchino/sticky-pull-request-comment@v3
         with:
-          header: source-security-scan-findings-${{ inputs.app-name || inputs.tenant-name || vars.TENANT_NAME }}
+          header: security-source-scan-findings-${{ inputs.app-name || inputs.tenant-name || vars.TENANT_NAME }}
           path: ${{ steps.report.outputs.report-file }}
           recreate: true
 
@@ -288,7 +288,7 @@ jobs:
         if: ${{ always() && inputs.dry-run == false }}
         uses: actions/upload-artifact@v7
         with:
-          name: source-security-scan-findings
+          name: security-source-scan-findings
           path: |
             ${{ runner.temp }}/source-security/trufflehog
             ${{ runner.temp }}/source-security/trivy
@@ -296,17 +296,17 @@ jobs:
           if-no-files-found: warn
           retention-days: 30
 
-  scan-status-policy:
-    name: source-security-scan-status-policy
+  security-source-scan-status-policy:
+    name: security-source-scan-status-policy
     runs-on: ubuntu-24.04
-    needs: [report]
+    needs: [security-source-report]
     if: ${{ always() && inputs.dry-run == false }}
     timeout-minutes: 1
     steps:
       - name: Enforce scanner execution status
         shell: bash
         env:
-          SCAN_STATUS: ${{ needs.report.outputs.scan-status || 'failed' }}
+          SCAN_STATUS: ${{ needs.security-source-report.outputs.scan-status || 'failed' }}
         run: |
           set -euo pipefail
           if [ "${SCAN_STATUS}" != "ok" ]; then
@@ -314,26 +314,26 @@ jobs:
             exit 1
           fi
 
-  policy:
-    name: source-security-policy
+  security-source-policy:
+    name: security-source-policy
     runs-on: ubuntu-24.04
-    needs: [report]
+    needs: [security-source-report]
     if: ${{ always() && inputs.dry-run == false }}
-    continue-on-error: ${{ inputs.blocking-severity == 'off' || (needs.report.outputs.vulnerability-blocking == '0' && needs.report.outputs.secret-blocking == '0') }}
+    continue-on-error: ${{ inputs.blocking-severity == 'off' || (needs.security-source-report.outputs.vulnerability-blocking == '0' && needs.security-source-report.outputs.secret-blocking == '0') }}
     timeout-minutes: 1
     steps:
-      - name: "Output security risk: ${{ needs.report.outputs.security-risk || 'unknown' }}; scan: ${{ needs.report.outputs.scan-status || 'failed' }}"
+      - name: "Output security risk: ${{ needs.security-source-report.outputs.security-risk || 'unknown' }}; scan: ${{ needs.security-source-report.outputs.scan-status || 'failed' }}"
         run: ':'
 
       - name: Enforce scan policy
         shell: bash
         env:
           BLOCKING_SEVERITY: ${{ inputs.blocking-severity }}
-          VULN_TOTAL: ${{ needs.report.outputs.vulnerability-total }}
-          VULN_BLOCKING: ${{ needs.report.outputs.vulnerability-blocking }}
-          LICENSE_TOTAL: ${{ needs.report.outputs.license-total }}
-          SECRET_TOTAL: ${{ needs.report.outputs.secret-total }}
-          SECRET_BLOCKING: ${{ needs.report.outputs.secret-blocking }}
+          VULN_TOTAL: ${{ needs.security-source-report.outputs.vulnerability-total }}
+          VULN_BLOCKING: ${{ needs.security-source-report.outputs.vulnerability-blocking }}
+          LICENSE_TOTAL: ${{ needs.security-source-report.outputs.license-total }}
+          SECRET_TOTAL: ${{ needs.security-source-report.outputs.secret-total }}
+          SECRET_BLOCKING: ${{ needs.security-source-report.outputs.secret-blocking }}
         run: |
           set -euo pipefail
           case "${BLOCKING_SEVERITY}" in

--- a/docs/explanation/image-scanning.md
+++ b/docs/explanation/image-scanning.md
@@ -14,9 +14,9 @@ The scheduled [`p2p-workflow-security-scan`](../reference/p2p-workflow-security-
 
 ## Blocking and reporting
 
-Image scanning is visibility-first by default. Both Trivy vulnerability findings and TruffleHog secret findings surface in the same workflow artifact, and in the same sticky PR comment for that app/stage/environment when the caller grants `pull-requests: write`. Findings fail the image-scan policy job. With the default `security-scan-blocking-severity: off`, or when findings are below a non-`off` threshold, that policy failure does not fail the workflow. Setting `security-scan-blocking-severity` to `low`, `medium`, `high`, or `critical` makes findings at or above that Trivy severity block the workflow; verified TruffleHog secrets are treated as `critical`.
+Image scanning is visibility-first by default. Both Trivy vulnerability findings and TruffleHog secret findings surface in the same workflow artifact, and in the same sticky PR comment for that app/stage/environment when the caller grants `pull-requests: write`. Findings fail the `security-image-policy` job. With the default `security-scan-blocking-severity: off`, or when findings are below a non-`off` threshold, that policy failure does not fail the workflow. Setting `security-scan-blocking-severity` to `low`, `medium`, `high`, or `critical` makes findings at or above that Trivy severity block the workflow; verified TruffleHog secrets are treated as `critical`.
 
-The uploaded `image-scan-reports-*` artifact is manifest-based evidence for dashboard ingestion. Its root `manifest.json` is the supported index and points to artifact-relative Trivy JSON reports plus TruffleHog image JSON-lines reports for scanned image/platform pairs. TruffleHog JSONL files can be empty when there are no image secrets; dashboard evidence uses detector, status, layer, and path metadata and does not expose secret values.
+The uploaded `security-image-scan-reports-*` artifact is manifest-based evidence for dashboard ingestion. Its root `manifest.json` is the supported index and points to artifact-relative Trivy JSON reports plus TruffleHog image JSON-lines reports for scanned image/platform pairs. TruffleHog JSONL files can be empty when there are no image secrets; dashboard evidence uses detector, status, layer, and path metadata and does not expose secret values.
 
 ## See also
 

--- a/docs/how-to/enable-scheduled-security-scanning.md
+++ b/docs/how-to/enable-scheduled-security-scanning.md
@@ -79,8 +79,8 @@ The first explicit image name is used to find the latest deployed version in eac
 Each run emits:
 
 - workflow summaries for source security and each image scan;
-- on non-dry-run source scans where report generation completes, `source-security-scan-findings`, retained for 30 days;
-- on successful non-dry-run image scans where a latest image tag is found, `image-scan-reports-<stage>-<github_env>` for each scanned stage/environment, retained for 30 days.
+- on non-dry-run source scans where report generation completes, `security-source-scan-findings`, retained for 30 days;
+- on successful non-dry-run image scans where a latest image tag is found, `security-image-scan-reports-<stage>-<github_env>` for each scanned stage/environment, retained for 30 days.
 
 The source artifact contains redacted TruffleHog output, raw Trivy filesystem output, and normalized merged JSON. Each image artifact contains a root `manifest.json`, Trivy vulnerability JSON reports, and TruffleHog image JSON-lines reports.
 

--- a/docs/how-to/triage-security-findings.md
+++ b/docs/how-to/triage-security-findings.md
@@ -8,11 +8,11 @@ On pull requests, the scanners upsert sticky comments in the PR conversation ins
 
 | Source | Sticky comment header | Artifact |
 |---|---|---|
-| Source vulnerabilities | `source-security-scan-findings-<app-name>` | `source-security-scan-findings` |
-| Source restricted/forbidden licenses | `source-security-scan-findings-<app-name>` | `source-security-scan-findings` |
-| Git tree secrets | `source-security-scan-findings-<app-name>` | `source-security-scan-findings` |
-| Image vulnerabilities | `image-scan-findings-<app-name>-<stage>-<github_env>` | `image-scan-reports-<stage>-<github_env>` |
-| Image secrets | `image-scan-findings-<app-name>-<stage>-<github_env>` (same comment as image vulnerabilities for that app/stage/environment) | `image-scan-reports-<stage>-<github_env>` |
+| Source vulnerabilities | `security-source-scan-findings-<app-name>` | `security-source-scan-findings` |
+| Source restricted/forbidden licenses | `security-source-scan-findings-<app-name>` | `security-source-scan-findings` |
+| Git tree secrets | `security-source-scan-findings-<app-name>` | `security-source-scan-findings` |
+| Image vulnerabilities | `security-image-scan-findings-<app-name>-<stage>-<github_env>` | `security-image-scan-reports-<stage>-<github_env>` |
+| Image secrets | `security-image-scan-findings-<app-name>-<stage>-<github_env>` (same comment as image vulnerabilities for that app/stage/environment) | `security-image-scan-reports-<stage>-<github_env>` |
 
 Restricted and forbidden license findings are shown for triage only. The source scan reports only HIGH and CRITICAL license classifications. Trivy's license classification is not a legal decision and is not a P2P-wide organization policy; confirm the finding against your organization's open-source policy before taking enforcement action.
 
@@ -22,7 +22,7 @@ P2P workflow templates pass `app-name` to security scans so each app updates its
 
 The source-security comment renders source vulnerabilities, restricted or forbidden licenses, and git-tree secrets under one header. Vulnerability rows include package, installed version, fixed version, CVE, and source where available. License rows identify the package and detected license. Git-tree secret rows show `Detector`, `Status`, `File`, `Line`, and `Commit`.
 
-The image-scan comment renders up to two tables under one header:
+The security-image-scan comment renders up to two tables under one header:
 
 - **Vulnerabilities**: a per-image summary table plus a `<details>` block per image with `Severity`, `Package`, `Installed`, `Fixed`, `CVE`, and `Source` columns. Sorted by severity, then package, then CVE; truncated to 100 rows.
 - **Secrets in image**: `Detector`, `Status`, `ID`, `Layer`, `Path`. `Status` is `verified`, `unknown`, or `unverified`; when blocking is enabled, `verified` rows are treated as `critical`. Use the `ID` value when adding an image secret ignore entry. Truncated independently at 100 rows.
@@ -36,10 +36,10 @@ If the PR comment is truncated or you need raw data:
 1. Open the workflow run from the PR checks or the Actions tab.
 2. In the run summary, open the **Artifacts** section.
 3. Download:
-   - `source-security-scan-findings` for source-security output (contains redacted TruffleHog findings, raw Trivy filesystem output, and `source-security-findings.json`)
-   - `image-scan-reports-<stage>-<github_env>` for image-scan output (contains `manifest.json`, `image-security-findings.json`, `trivy/`, and `trufflehog-image/`)
+   - `security-source-scan-findings` for source-security output (contains redacted TruffleHog findings, raw Trivy filesystem output, and `source-security-findings.json`)
+   - `security-image-scan-reports-<stage>-<github_env>` for security-image-scan output (contains `manifest.json`, `image-security-findings.json`, `trivy/`, and `trufflehog-image/`)
 
-The image artifact's root `manifest.json` is the supported index. It records the stage and points to artifact-relative raw Trivy JSON reports under `trivy/` and redacted TruffleHog JSON-lines reports under `trufflehog-image/`, both keyed by scanned image x platform. A configured OCI reference can be absent from `manifest.json` when the workflow skipped it as non-scannable, such as a Helm chart artifact or confirmed empty container image; check the image-scan job logs for skip warnings. A TruffleHog JSONL file can be empty when no image secrets were found. Dashboard evidence does not expose secret values; use the P2P redacted secret ID, detector, status, layer, and path metadata for triage. The source-security artifact contains raw Trivy filesystem output, redacted TruffleHog source findings, and `source-security-findings.json` for source vulnerabilities, source license findings, and git-tree secrets.
+The image artifact's root `manifest.json` is the supported index. It records the stage and points to artifact-relative raw Trivy JSON reports under `trivy/` and redacted TruffleHog JSON-lines reports under `trufflehog-image/`, both keyed by scanned image x platform. A configured OCI reference can be absent from `manifest.json` when the workflow skipped it as non-scannable, such as a Helm chart artifact or confirmed empty container image; check the security-image-scan job logs for skip warnings. A TruffleHog JSONL file can be empty when no image secrets were found. Dashboard evidence does not expose secret values; use the P2P redacted secret ID, detector, status, layer, and path metadata for triage. The `security-source-scan-findings` artifact contains raw Trivy filesystem output, redacted TruffleHog source findings, and `source-security-findings.json` for source vulnerabilities, source license findings, and git-tree secrets.
 
 `source-security-findings.json` uses top-level `vulnerabilities`, `licenses`, and `secrets` collections. `image-security-findings.json` uses top-level `vulnerabilities` and `secrets` collections. When an ignore file is present, both files also include `ignored.vulnerabilities` and `ignored.secrets`; ignored records include the matched reason and expiry metadata when present. This lets dashboard ingestion display ignored findings alongside active findings without treating them as active remediation or blocking policy counts.
 

--- a/docs/reference/p2p-workflow-extended-test.md
+++ b/docs/reference/p2p-workflow-extended-test.md
@@ -42,7 +42,7 @@ This workflow runs image scanning before promotion. The image scan authenticates
 | `tenant-name` | `string` | No | `''` | Tenant name passed to all make targets. |
 | `skip-subnamespaces-create` | `boolean` | No | `false` | Skips creating subnamespaces before running make targets. |
 | `artifacts` | `string` | No | `''` | YAML-formatted map of make target names to artifact paths. Paths matching each active command are uploaded after that command runs. |
-| `security-scan-blocking-severity` | `string` | No | `off` | Minimum image-scan finding severity that blocks the workflow: `off`, `low`, `medium`, `high`, or `critical`. Verified image secrets are treated as `critical`. The policy job fails on active findings, but the workflow continues when findings are below the blocking threshold. |
+| `security-scan-blocking-severity` | `string` | No | `off` | Minimum security-image-scan finding severity that blocks the workflow: `off`, `low`, `medium`, `high`, or `critical`. Verified image secrets are treated as `critical`. The policy job fails on active findings, but the workflow continues when findings are below the blocking threshold. |
 
 ## Secrets
 
@@ -64,19 +64,19 @@ This workflow defines no outputs.
 run-tests     Runs p2p-extended-test make target.
               Only runs on main-branch.
               checkout-version = version-prefix + version.
-└── promote   (needs: run-tests, image-scan)
+└── promote   (needs: run-tests, security-image-scan)
               Promotes from source to destination environments.
               Only runs on main-branch.
               checkout-version = version-prefix + version.
 
-image-scan    (independent of run-tests; runs in parallel)
+security-image-scan    (independent of run-tests; runs in parallel)
               Calls p2p-workflow-image-scan against the source images.
               Only runs on main-branch.
               checkout-version = version-prefix + version.
               Blocks the workflow on findings at or above
               security-scan-blocking-severity (default: off).
 
-notify-failure  (needs: run-tests, image-scan, promote; runs on main-branch when any job fails)
+notify-failure  (needs: run-tests, security-image-scan, promote; runs on main-branch when any job fails)
 ```
 
 All jobs use a matrix derived from `source`. The `promote` job uses a matrix derived from `destination`.

--- a/docs/reference/p2p-workflow-fastfeedback.md
+++ b/docs/reference/p2p-workflow-fastfeedback.md
@@ -73,16 +73,16 @@ build
     └── integration-test  (needs: functional-test, nft-test)
                           Skipped when skip-fastfeedback-integration-on-prs=true
                           AND ref is not main-branch AND ref_type is not tag.
-        └── promote       (needs: integration-test, image-scan, source-security-scan)
+        └── promote       (needs: integration-test, security-image-scan, security-source-scan)
                           Runs only on main-branch or tag pushes.
 
-image-scan           (needs: build)
+security-image-scan           (needs: build)
                      Calls p2p-workflow-image-scan against the built images.
                      Checks out the same checkout-version ref for image target resolution.
                      Blocks the workflow on findings at or above
                      security-scan-blocking-severity (default: off).
 
-source-security-scan  (independent of build; runs in parallel)
+security-source-scan  (independent of build; runs in parallel)
                       Calls p2p-workflow-source-security-scan with secret-scan-scope: changes.
                       Checks out the same checkout-version ref as build/test jobs.
                       Reports source vulnerabilities, restricted/forbidden licenses,
@@ -93,7 +93,7 @@ source-security-scan  (independent of build; runs in parallel)
 notify-failure       (needs: all jobs; runs on main-branch when any job fails)
 ```
 
-All jobs use a matrix derived from `source`. The `promote` job uses a matrix derived from `destination`. The `source-security-scan` job is not part of the matrix; it runs once per workflow. Security PR comments are scoped to `app-name`.
+All jobs use a matrix derived from `source`. The `promote` job uses a matrix derived from `destination`. The `security-source-scan` job is not part of the matrix; it runs once per workflow. Security PR comments are scoped to `app-name`.
 
 ## See also
 

--- a/docs/reference/p2p-workflow-image-scan.md
+++ b/docs/reference/p2p-workflow-image-scan.md
@@ -1,6 +1,6 @@
 # p2p-workflow-image-scan
 
-> Scans every scannable container image resolved by the repository's P2P image targets for known vulnerabilities (Trivy) and embedded secrets (TruffleHog). Produces a workflow summary, optionally posts a sticky PR comment on `pull_request` events, and uploads an `image-scan-reports-<stage>-<github_env>` artifact. A separate policy job fails on active vulnerability or secret findings; the configured blocking severity controls whether that policy failure fails the workflow.
+> Scans every scannable container image resolved by the repository's P2P image targets for known vulnerabilities (Trivy) and embedded secrets (TruffleHog). Produces a workflow summary, optionally posts a sticky PR comment on `pull_request` events, and uploads a `security-image-scan-reports-<stage>-<github_env>` artifact. The `security-image-policy` job fails on active vulnerability or secret findings; the configured blocking severity controls whether that policy failure fails the workflow.
 
 ## Usage
 
@@ -20,7 +20,7 @@ Internal workflow called by [`p2p-workflow-fastfeedback`](p2p-workflow-fastfeedb
 | `image-names` | string | No | `''` | Newline-, comma-, or whitespace-separated list of standard P2P image names to scan. When set, this list is used instead of `make p2p-images`. |
 | `dry-run` | boolean | No | `false` | When `true`, still checks out the repo and resolves image names from `image-names` or `make p2p-images`, then skips GCP auth, registry login, image pulls, scanner installs, scans, sticky PR comment, artifact upload, and policy step. The `Build report` step still runs and produces a "Scan skipped" summary. Dry-run still parses `.p2p-security-ignore.yaml`, so a malformed ignore file can fail report generation. |
 | `checkout-version` | string | No | `''` | Git ref to check out before resolving image names. Ignored when `dry-run` is `true`; the workflow checks out the default ref. |
-| `blocking-severity` | string | No | `off` | Minimum finding severity that blocks the workflow: `off`, `low`, `medium`, `high`, or `critical`. When blocking is enabled, verified image secrets are treated as `critical`. The policy job fails on active vulnerability or secret findings, but the workflow continues when findings are below the blocking threshold. |
+| `blocking-severity` | string | No | `off` | Minimum finding severity that blocks the workflow: `off`, `low`, `medium`, `high`, or `critical`. When blocking is enabled, verified image secrets are treated as `critical`. The `security-image-policy` job fails on active vulnerability or secret findings, but the workflow continues when findings are below the blocking threshold. |
 | `ignore-unfixed` | boolean | No | `true` | When `true`, passes `--ignore-unfixed` to Trivy — only vulnerabilities with a fixed version are reported. |
 | `timeout-minutes` | number | No | `20` | Job timeout. |
 
@@ -39,7 +39,7 @@ Tenant-provided registry login runs only when `container_registry_user`, `contai
 
 | Name | Description |
 |------|-------------|
-| `json-file` | Path to `image-security-findings.json` on the runner, normally under `runner.temp` or the image-scan artifact directory. |
+| `json-file` | Path to `image-security-findings.json` on the runner, normally under `runner.temp` or the security-image-scan artifact directory. |
 | `security-risk` | Maximum active image vulnerability/secret risk after ignore rules: `critical`, `unclassified`, `high`, `medium`, `low`, `ok`, or `unknown`. |
 | `scan-status` | `ok` when scanner results were extracted successfully, otherwise `failed`. |
 
@@ -47,8 +47,8 @@ Results are also surfaced via:
 
 - The workflow summary (`$GITHUB_STEP_SUMMARY`).
 - Policy step named `Output security risk: <risk>; scan: <status>` for dashboard extraction.
-- A sticky PR comment with `header: image-scan-findings-<app-name>-<stage>-<github_env>` on `pull_request` events when `dry-run: false` and the caller grants `pull-requests: write`. When `github_env` is empty, the header uses `local`.
-- The `image-scan-reports-<stage>-<github_env>` artifact, retained for 30 days. When `github_env` is empty, the artifact name uses `local`. Contains root `manifest.json`, `image-security-findings.json`, `trivy/` (one Trivy JSON per scanned image x platform), and `trufflehog-image/` (one redacted TruffleHog JSON-lines file per scanned image x platform).
+- A sticky PR comment with `header: security-image-scan-findings-<app-name>-<stage>-<github_env>` on `pull_request` events when `dry-run: false` and the caller grants `pull-requests: write`. When `github_env` is empty, the header uses `local`.
+- The `security-image-scan-reports-<stage>-<github_env>` artifact, retained for 30 days. When `github_env` is empty, the artifact name uses `local`. Contains root `manifest.json`, `image-security-findings.json`, `trivy/` (one Trivy JSON per scanned image x platform), and `trufflehog-image/` (one redacted TruffleHog JSON-lines file per scanned image x platform).
 
 If the repository root contains `.p2p-security-ignore.yaml`, image vulnerability and image secret findings that match a valid, unexpired ignore entry are omitted from active finding tables in the workflow summary and sticky PR comment. Ignored findings stay visible in `image-security-findings.json` with their ignore reason and expiry metadata when present. They are excluded from active totals, active blocking counts, and image policy failures.
 
@@ -80,13 +80,13 @@ If neither `image-names` nor `p2p-images` produces candidate names, or if all ca
 
 ## Security ignore file
 
-The image scan workflow reads one P2P-owned ignore file from the repository root: `.p2p-security-ignore.yaml`. If the file is absent, scans behave normally. If it is present but malformed, uses an unsupported schema version, omits required fields, has invalid shapes, or contains invalid expiry dates, the scan/report job fails.
+The security-image-scan workflow reads one P2P-owned ignore file from the repository root: `.p2p-security-ignore.yaml`. If the file is absent, scans behave normally. If it is present but malformed, uses an unsupported schema version, omits required fields, has invalid shapes, or contains invalid expiry dates, the scan/report job fails.
 
 See [How to ignore security findings](../how-to/ignore-security-findings.md) for the v1 schema, matching rules, and secret ID guidance.
 
 ## Artifact contract
 
-Each published `image-scan-reports-<stage>-<github_env>` artifact is complete dashboard image evidence for the scannable container images that were actually scanned. The root `manifest.json` is the supported artifact index; `reports.txt` files are runner-local implementation detail and are not published or supported for downstream parsing. Candidate OCI references skipped as non-scannable are visible in job logs, not in the artifact.
+Each published `security-image-scan-reports-<stage>-<github_env>` artifact is complete dashboard image evidence for the scannable container images that were actually scanned. The root `manifest.json` is the supported artifact index; `reports.txt` files are runner-local implementation detail and are not published or supported for downstream parsing. Candidate OCI references skipped as non-scannable are visible in job logs, not in the artifact.
 
 Manifest schema version 1:
 
@@ -114,7 +114,7 @@ Manifest schema version 1:
 - `secretReport` is an artifact-relative path to a redacted TruffleHog JSON-lines report under `trufflehog-image/`; the file may be empty when TruffleHog finds no secrets.
 - Report paths must be relative to the artifact root, must not be absolute, must not contain parent-directory traversal, and must point to files in the same artifact.
 
-If scanning, report generation, or manifest validation is incomplete, the workflow does not upload a dashboard-matching `image-scan-reports-*` artifact. Use the failed job logs as the diagnostic surface.
+If scanning, report generation, or manifest validation is incomplete, the workflow does not upload a dashboard-matching `security-image-scan-reports-*` artifact. Use the failed job logs as the diagnostic surface.
 
 ## Report format
 

--- a/docs/reference/p2p-workflow-prod.md
+++ b/docs/reference/p2p-workflow-prod.md
@@ -49,7 +49,7 @@ This workflow runs image scanning before deployment. The image scan authenticate
 | `app-name` | `string` | No | `''` | Application name. Must equal the tenant name (each application has its own application tenant). Also scopes image security sticky PR comments so multi-app repositories do not overwrite comments between apps. |
 | `tenant-name` | `string` | No | `''` | Tenant name passed to the make target. |
 | `skip-subnamespaces-create` | `boolean` | No | `false` | Skips creating subnamespaces before running the make target. |
-| `security-scan-blocking-severity` | `string` | No | `off` | Minimum image-scan finding severity that blocks the workflow: `off`, `low`, `medium`, `high`, or `critical`. Verified image secrets are treated as `critical`. The policy job fails on active findings, but the workflow continues when findings are below the blocking threshold. |
+| `security-scan-blocking-severity` | `string` | No | `off` | Minimum security-image-scan finding severity that blocks the workflow: `off`, `low`, `medium`, `high`, or `critical`. Verified image secrets are treated as `critical`. The policy job fails on active findings, but the workflow continues when findings are below the blocking threshold. |
 
 ## Secrets
 
@@ -71,17 +71,17 @@ This workflow defines no outputs.
 validate-version
                 Fails early when version is empty.
 
-└── image-scan  Calls p2p-workflow-image-scan against the prod-registry images.
+└── security-image-scan  Calls p2p-workflow-image-scan against the prod-registry images.
                 Only runs on main-branch.
                 checkout-version = version-prefix + version.
                 Blocks the workflow on findings at or above
                 security-scan-blocking-severity (default: off).
-└── prod-deploy (needs: image-scan)
+└── prod-deploy (needs: security-image-scan)
                 Runs p2p-prod make target.
-                Only runs on main-branch after image-scan succeeds.
+                Only runs on main-branch after security-image-scan succeeds.
                 checkout-version = version-prefix + version.
 
-notify-failure  (needs: validate-version, image-scan, prod-deploy; runs on main-branch when any job fails)
+notify-failure  (needs: validate-version, security-image-scan, prod-deploy; runs on main-branch when any job fails)
 notify-success  (needs: prod-deploy; runs on main-branch when prod-deploy succeeds and dry-run=false)
 ```
 

--- a/docs/reference/p2p-workflow-security-scan.md
+++ b/docs/reference/p2p-workflow-security-scan.md
@@ -43,41 +43,41 @@ jobs:
 | `dry-run` | boolean | No | `false` | Passed through to child workflows; still resolves the anchor image from `image-names` or `make p2p-images`, then skips registry lookups and scans. |
 | `checkout-version` | string | No | `''` | Internal consistency input for child checkouts. Application wrappers should normally omit it. |
 | `security-scan-blocking-severity` | string | No | `off` | Minimum security finding severity that blocks the umbrella workflow: `off`, `low`, `medium`, `high`, or `critical`. When blocking is enabled, verified secrets are treated as `critical`. Child policy jobs fail on active findings, but the umbrella workflow continues when findings are below the blocking threshold. |
-| `timeout-minutes` | number | No | `30` | Timeout for the `source-security-scan` job. Image-scan jobs use their own default. |
+| `timeout-minutes` | number | No | `30` | Timeout for the `security-source-scan` job. security-image-scan jobs use their own default. |
 
 ## Secrets
 
 | Name | Required | Description |
 |------|----------|-------------|
-| `env_vars` | No | Forwarded to image discovery and image scan child workflows. |
-| `container_registry_user` | No | Forwarded to image-scan when private base images need authentication. |
-| `container_registry_pat` | No | Forwarded to image-scan. |
-| `container_registry_url` | No | Forwarded to image-scan. |
+| `env_vars` | No | Forwarded to image discovery and security-image-scan child workflows. |
+| `container_registry_user` | No | Forwarded to security-image-scan when private base images need authentication. |
+| `container_registry_pat` | No | Forwarded to security-image-scan. |
+| `container_registry_url` | No | Forwarded to security-image-scan. |
 
 ## Outputs
 
 None. Results are surfaced via:
 
 - Each child job's workflow summary (`$GITHUB_STEP_SUMMARY`).
-- On non-dry-run source scans where report generation completes, the `source-security-scan-findings` artifact from the source-security-scan job. It contains redacted TruffleHog output, raw Trivy filesystem output when available, and normalized merged JSON. Scheduled source scanning uses TruffleHog for reachable git history and Trivy for the current branch's checked-out source tree. Scanner warnings or incomplete scanner output still fail the scan-status policy job.
-- On successful non-dry-run image scans where a latest image tag is found and at least one scannable container image is available, the `image-scan-reports-<stage>-<github_env>` artifact from each image-scan job. Each artifact contains root `manifest.json`, `trivy/` vulnerability JSON reports, and `trufflehog-image/` secret JSON-lines reports for scanned image/platform pairs. `manifest.json` records the P2P stage (`fast-feedback`, `extended-test`, or `prod`) and is the supported artifact index.
+- On non-dry-run source scans where report generation completes, the `security-source-scan-findings` artifact from the security-source-scan job. It contains redacted TruffleHog output, raw Trivy filesystem output when available, and normalized merged JSON. Scheduled source scanning uses TruffleHog for reachable git history and Trivy for the current branch's checked-out source tree. Scanner warnings or incomplete scanner output still fail the `security-source-scan-status-policy` job.
+- On successful non-dry-run image scans where a latest image tag is found and at least one scannable container image is available, the `security-image-scan-reports-<stage>-<github_env>` artifact from each security-image-scan job. Each artifact contains root `manifest.json`, `trivy/` vulnerability JSON reports, and `trufflehog-image/` secret JSON-lines reports for scanned image/platform pairs. `manifest.json` records the P2P stage (`fast-feedback`, `extended-test`, or `prod`) and is the supported artifact index.
 
 ## Job Graph
 
 ```
-resolve-anchor-image
-├── image-scan-fast-feedback  (matrix: vars.FAST_FEEDBACK)
-├── image-scan-extended-test  (matrix: vars.EXTENDED_TEST)
-└── image-scan-prod           (matrix: vars.PROD)
+security-resolve-anchor-image
+├── security-image-scan-fast-feedback  (matrix: vars.FAST_FEEDBACK)
+├── security-image-scan-extended-test  (matrix: vars.EXTENDED_TEST)
+└── security-image-scan-prod           (matrix: vars.PROD)
 
-source-security-scan                                   (independent; runs in parallel)
+security-source-scan                                   (independent; runs in parallel)
 ```
 
-Each matrix entry calls an internal stage workflow that first discovers the latest version for that stage/environment and then scans that exact version. The source-security-scan job runs in parallel with the per-stage matrices. For source scans, `secret-scan-scope: full-history` applies to TruffleHog git scanning; Trivy scans only the current checked-out branch tree. The `security-scan-blocking-severity` input is passed to every child scan. Its default `off` keeps scheduled scans report-only; setting it to `low`, `medium`, `high`, or `critical` makes findings at or above that severity fail the umbrella workflow, while below-threshold findings fail only the child policy job.
+Each matrix entry calls an internal stage workflow that first discovers the latest version for that stage/environment and then scans that exact version. The security-source-scan job runs in parallel with the per-stage matrices. For source scans, `secret-scan-scope: full-history` applies to TruffleHog git scanning; Trivy scans only the current checked-out branch tree. The `security-scan-blocking-severity` input is passed to every child scan. Its default `off` keeps scheduled scans report-only; setting it to `low`, `medium`, `high`, or `critical` makes findings at or above that severity fail the umbrella workflow, while below-threshold findings fail only the child policy job.
 
 ## Version discovery
 
-For each stage/environment matrix entry, the umbrella calls [`p2p-get-latest-image`](p2p-get-latest-image.md) with the anchor image to determine the highest semver-sorted tag in that stage's registry path. That version is passed to the image-scan workflow for the same GitHub environment. If no tag is found for that stage/environment, the image scan is skipped after logging the missing image. Because all images in a p2p release share the same version, scanning at the anchor's version covers the whole configured image set; the image-scan workflow still filters each configured reference to the scannable container images before running scanners.
+For each stage/environment matrix entry, the umbrella calls [`p2p-get-latest-image`](p2p-get-latest-image.md) with the anchor image to determine the highest semver-sorted tag in that stage's registry path. That version is passed to the security-image-scan workflow for the same GitHub environment. If no tag is found for that stage/environment, the image scan is skipped after logging the missing image. Because all images in a p2p release share the same version, scanning at the anchor's version covers the whole configured image set; the security-image-scan workflow still filters each configured reference to the scannable container images before running scanners.
 
 ## See also
 

--- a/docs/reference/p2p-workflow-source-security-scan.md
+++ b/docs/reference/p2p-workflow-source-security-scan.md
@@ -1,6 +1,6 @@
 # p2p-workflow-source-security-scan
 
-> Scans repository source for committed secrets, dependency vulnerabilities, and restricted or forbidden licenses. Produces a workflow summary, optionally posts a sticky PR comment on `pull_request` events when permissions allow, and uploads a `source-security-scan-findings` artifact. A separate policy job fails on active vulnerability or secret findings; the configured blocking severity controls whether that policy failure fails the workflow.
+> Scans repository source for committed secrets, dependency vulnerabilities, and restricted or forbidden licenses. Produces a workflow summary, optionally posts a sticky PR comment on `pull_request` events when permissions allow, and uploads a `security-source-scan-findings` artifact. The `security-source-policy` job fails on active vulnerability or secret findings; the configured blocking severity controls whether that policy failure fails the workflow.
 
 ## Usage
 
@@ -13,7 +13,7 @@ Internal workflow called from [`p2p-workflow-fastfeedback`](p2p-workflow-fastfee
 | `secret-scan-scope` | string | Yes | - | `changes` for PR/push scanning or `full-history` for scheduled monitoring. TruffleHog uses this to choose git history scope. Trivy scans the current checked-out source tree. |
 | `app-name` | string | No | `''` | Application name used to scope sticky PR comments in multi-app repositories. Primary P2P workflow templates pass this through. When omitted by direct callers, comment scope falls back to `tenant-name`, then `vars.TENANT_NAME`. |
 | `tenant-name` | string | No | `''` | Tenant identifier used as the sticky comment scope fallback when `app-name` is omitted. |
-| `blocking-severity` | string | No | `off` | Minimum finding severity that blocks the workflow: `off`, `low`, `medium`, `high`, or `critical`. When blocking is enabled, verified secrets are treated as `critical`. The policy job fails on active vulnerability or secret findings, but the workflow continues when findings are below the blocking threshold. |
+| `blocking-severity` | string | No | `off` | Minimum finding severity that blocks the workflow: `off`, `low`, `medium`, `high`, or `critical`. When blocking is enabled, verified secrets are treated as `critical`. The `security-source-policy` job fails on active vulnerability or secret findings, but the workflow continues when findings are below the blocking threshold. |
 | `ignore-unfixed` | boolean | No | `true` | Passed to Trivy vulnerability scanning. |
 | `dry-run` | boolean | No | `false` | When `true`, skips scanner installs, scans, sticky PR comments, artifact upload, and policy enforcement. The summary reports that the scan was skipped. Dry-run still parses `.p2p-security-ignore.yaml`, so a malformed ignore file can fail report generation. |
 | `checkout-version` | string | No | `''` | Git ref to check out before scanning. Ignored when `dry-run` is `true`; the workflow checks out the default ref. |
@@ -46,8 +46,8 @@ Results are also surfaced via:
 
 - workflow summary;
 - policy step named `Output security risk: <risk>; scan: <status>` for dashboard extraction;
-- sticky PR comment with `header: source-security-scan-findings-<app-name>` on `pull_request` events;
-- `source-security-scan-findings` artifact containing redacted TruffleHog findings, raw Trivy filesystem output, and `source-security-findings.json`.
+- sticky PR comment with `header: security-source-scan-findings-<app-name>` on `pull_request` events;
+- `security-source-scan-findings` artifact containing redacted TruffleHog findings, raw Trivy filesystem output, and `source-security-findings.json`.
 
 If the repository root contains `.p2p-security-ignore.yaml`, source vulnerability and source secret findings that match a valid, unexpired ignore entry are omitted from active finding tables in the workflow summary and sticky PR comment. Ignored findings stay visible in `source-security-findings.json` with their ignore reason and expiry metadata when present. They are excluded from active totals, active blocking counts, and policy failures.
 
@@ -65,8 +65,8 @@ See [How to ignore security findings](../how-to/ignore-security-findings.md) for
 
 The workflow is visibility-first by default. Scanner setup or execution errors always fail the workflow. Finding policy is controlled by `blocking-severity`:
 
-- `off`: findings do not fail the workflow, but the `source-security-policy` job fails when vulnerabilities or secrets are found;
-- `low`, `medium`, `high`, or `critical`: reported Trivy vulnerability findings below that threshold fail only the policy job, while findings at or above that threshold fail the workflow;
+- `off`: findings do not fail the workflow, but the `security-source-policy` job fails when vulnerabilities or secrets are found;
+- `low`, `medium`, `high`, or `critical`: reported Trivy vulnerability findings below that threshold fail only the `security-source-policy` job, while findings at or above that threshold fail the workflow;
 - verified TruffleHog secrets are treated as `critical` findings and fail the workflow for any non-`off` threshold.
 
 Restricted and forbidden license findings are report-only for every threshold. The source scan reports only HIGH and CRITICAL license classifications.

--- a/docs/tutorials/getting-started.md
+++ b/docs/tutorials/getting-started.md
@@ -105,11 +105,11 @@ In the GitHub Actions UI you'll see:
 1. `version` starts immediately and tags the commit (on `main`) or produces a pre-release version string (on a PR).
 2. `fastfeedback` starts once `version` completes. Inside it, the job graph runs:
    - `build` runs first across every environment in `FAST_FEEDBACK`.
-   - `source-security-scan` runs independently of `build`.
-   - `image-scan` runs once `build` succeeds.
+   - `security-source-scan` runs independently of `build`.
+   - `security-image-scan` runs once `build` succeeds.
    - `functional-test` and `nft-test` run in parallel once build succeeds.
    - `integration-test` runs after both `functional-test` and `nft-test` succeed.
-   - `promote` runs last (on `main` only), after `integration-test`, `image-scan`, and `source-security-scan` have all succeeded, and copies the image into the `EXTENDED_TEST` registry path.
+   - `promote` runs last (on `main` only), after `integration-test`, `security-image-scan`, and `security-source-scan` have all succeeded, and copies the image into the `EXTENDED_TEST` registry path.
 
 ## What happens next
 


### PR DESCRIPTION
## Summary

- Prefix security-related workflow job/check names with `security-` across P2P workflows.
- Update dependent `needs`, reusable workflow outputs, PR comment headers, artifact names, and internal assertions.
- Refresh tracked docs so public job/check/comment/artifact names match the new naming.

## Validation

- `node .github/scripts/tests/source-security-ignore-report.test.js`
- `node .github/scripts/tests/image-security-ignore-report.test.js`
- `node .github/scripts/tests/image-scan-targets.test.js`
- `node .github/scripts/tests/image-scan-manifest.test.js`
- `node .github/scripts/tests/image-ref-resolution.test.js`
- `node .github/scripts/tests/security-ignore-helper.test.js`
- `node .github/scripts/tests/source-secret-redaction.test.js`
- `actionlint` on changed workflows
- Markdown relative link check
- Ruby YAML parse for workflows
- `git diff --check`