### PR TITLE
[codex] Fix latest image tag resolver

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,4 +1,11 @@
 paths:
+  .github/workflows/p2p-get-latest-image.yaml:
+    ignore:
+      # GitHub documents job.workflow_repository/job.workflow_sha for reusable
+      # workflows that need to check out their own source, but actionlint
+      # v1.7.12 does not include these job context fields yet.
+      - 'property "workflow_repository" is not defined in object type'
+      - 'property "workflow_sha" is not defined in object type'
   .github/workflows/p2p-workflow-image-scan.yaml:
     ignore:
       # GitHub documents job.workflow_repository/job.workflow_sha for reusable

--- a/.github/scripts/latest-image.js
+++ b/.github/scripts/latest-image.js
@@ -1,0 +1,98 @@
+function parseSemverTag(tag) {
+  const value = String(tag || '').trim();
+  const match = value.match(/^v?(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z.-]+))?(?:\+([0-9A-Za-z.-]+))?$/);
+  if (!match) return null;
+
+  return {
+    original: value,
+    core: [Number(match[1]), Number(match[2]), Number(match[3])],
+    prerelease: match[4] ? match[4].split('.') : [],
+  };
+}
+
+function isNumericPrereleaseIdentifier(value) {
+  return /^(0|[1-9]\d*)$/.test(value);
+}
+
+function comparePrereleaseIdentifier(left, right) {
+  const leftNumeric = isNumericPrereleaseIdentifier(left);
+  const rightNumeric = isNumericPrereleaseIdentifier(right);
+
+  if (leftNumeric && rightNumeric) return Number(left) - Number(right);
+  if (leftNumeric) return -1;
+  if (rightNumeric) return 1;
+  if (left < right) return -1;
+  if (left > right) return 1;
+  return 0;
+}
+
+function compareSemver(left, right) {
+  for (let i = 0; i < 3; i += 1) {
+    if (left.core[i] !== right.core[i]) return left.core[i] - right.core[i];
+  }
+
+  const leftIsRelease = left.prerelease.length === 0;
+  const rightIsRelease = right.prerelease.length === 0;
+  if (leftIsRelease && rightIsRelease) return 0;
+  if (leftIsRelease) return 1;
+  if (rightIsRelease) return -1;
+
+  const maxLength = Math.max(left.prerelease.length, right.prerelease.length);
+  for (let i = 0; i < maxLength; i += 1) {
+    if (left.prerelease[i] === undefined) return -1;
+    if (right.prerelease[i] === undefined) return 1;
+    const result = comparePrereleaseIdentifier(left.prerelease[i], right.prerelease[i]);
+    if (result !== 0) return result;
+  }
+  return 0;
+}
+
+function selectLatestTag(tags) {
+  let latest = null;
+  for (const tag of tags) {
+    const candidate = parseSemverTag(tag);
+    if (!candidate) continue;
+    if (!latest || compareSemver(candidate, latest) > 0) latest = candidate;
+  }
+  return latest ? latest.original : '';
+}
+
+function extractArtifactRegistryTags(images) {
+  if (!Array.isArray(images)) return [];
+  if (images.every(item => typeof item === 'string')) return images;
+
+  const tags = [];
+  for (const image of images) {
+    if (!Array.isArray(image?.tags)) continue;
+    for (const tag of image.tags) tags.push(tag);
+  }
+  return tags;
+}
+
+function parseInput(input) {
+  const trimmed = String(input || '').trim();
+  if (!trimmed) return [];
+
+  try {
+    return extractArtifactRegistryTags(JSON.parse(trimmed));
+  } catch {
+    return trimmed.split(/\r?\n/).map(line => line.trim()).filter(Boolean);
+  }
+}
+
+if (require.main === module) {
+  let input = '';
+  process.stdin.setEncoding('utf8');
+  process.stdin.on('data', chunk => { input += chunk; });
+  process.stdin.on('end', () => {
+    process.stdout.write(selectLatestTag(parseInput(input)));
+  });
+}
+
+module.exports = {
+  compareSemver,
+  extractArtifactRegistryTags,
+  parseInput,
+  parseSemverTag,
+  selectLatestTag,
+};

--- a/.github/scripts/latest-image.js
+++ b/.github/scripts/latest-image.js
@@ -1,6 +1,16 @@
+const NUMERIC_IDENTIFIER = '(?:0|[1-9]\\d*)';
+const NON_NUMERIC_IDENTIFIER = '(?:[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*)';
+const PRERELEASE_IDENTIFIER = `(?:${NUMERIC_IDENTIFIER}|${NON_NUMERIC_IDENTIFIER})`;
+const BUILD_IDENTIFIER = '(?:[0-9A-Za-z-]+)';
+const SEMVER_TAG_PATTERN = new RegExp(
+  `^v?(${NUMERIC_IDENTIFIER})\\.(${NUMERIC_IDENTIFIER})\\.(${NUMERIC_IDENTIFIER})` +
+  `(?:-(${PRERELEASE_IDENTIFIER}(?:\\.${PRERELEASE_IDENTIFIER})*))?` +
+  `(?:\\+(${BUILD_IDENTIFIER}(?:\\.${BUILD_IDENTIFIER})*))?$`,
+);
+
 function parseSemverTag(tag) {
   const value = String(tag || '').trim();
-  const match = value.match(/^v?(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z.-]+))?(?:\+([0-9A-Za-z.-]+))?$/);
+  const match = value.match(SEMVER_TAG_PATTERN);
   if (!match) return null;
 
   return {

--- a/.github/scripts/tests/latest-image.test.js
+++ b/.github/scripts/tests/latest-image.test.js
@@ -37,6 +37,24 @@ assert.strictEqual(
   'ignores non-SemVer tags',
 );
 
+assert.strictEqual(
+  selectLatestTag(['01.2.3', '1.02.3', '1.2.03', '1.2.2']),
+  '1.2.2',
+  'ignores core versions with leading zeroes',
+);
+
+assert.strictEqual(
+  selectLatestTag(['1.2.3-01', '1.2.3-alpha..1', '1.2.3-', '1.2.2']),
+  '1.2.2',
+  'ignores malformed prerelease identifiers',
+);
+
+assert.strictEqual(
+  selectLatestTag(['1.2.3+001', '1.2.2']),
+  '1.2.3+001',
+  'accepts leading zeroes in build metadata identifiers',
+);
+
 const artifactRegistryJson = JSON.stringify([
   { tags: ['v0.0.5', '0.0.204-abc123'] },
   { tags: ['0.0.204'] },

--- a/.github/scripts/tests/latest-image.test.js
+++ b/.github/scripts/tests/latest-image.test.js
@@ -1,0 +1,50 @@
+const assert = require('assert');
+const { parseInput, selectLatestTag } = require('../latest-image');
+
+assert.strictEqual(
+  selectLatestTag(['0.0.204', '0.0.204-abc123', 'v0.0.5']),
+  '0.0.204',
+  'normalizes optional leading v before comparing versions',
+);
+
+assert.strictEqual(
+  selectLatestTag(['0.0.204-ff00aa', '0.0.204']),
+  '0.0.204',
+  'release versions rank above prereleases with the same core',
+);
+
+assert.strictEqual(
+  selectLatestTag(['v1.2.3', '1.2.2']),
+  'v1.2.3',
+  'returns the original selected tag after normalization',
+);
+
+assert.strictEqual(
+  selectLatestTag(['1.2.3-alpha.1', '1.2.3-alpha.2', '1.2.3-alpha.beta']),
+  '1.2.3-alpha.beta',
+  'preserves SemVer prerelease identifier ordering',
+);
+
+assert.strictEqual(
+  selectLatestTag(['1.2.3+build.9', '1.2.3+build.1']),
+  '1.2.3+build.9',
+  'keeps the first original tag when normalized SemVer values tie',
+);
+
+assert.strictEqual(
+  selectLatestTag(['not-a-version', '0.9.0']),
+  '0.9.0',
+  'ignores non-SemVer tags',
+);
+
+const artifactRegistryJson = JSON.stringify([
+  { tags: ['v0.0.5', '0.0.204-abc123'] },
+  { tags: ['0.0.204'] },
+]);
+assert.strictEqual(
+  selectLatestTag(parseInput(artifactRegistryJson)),
+  '0.0.204',
+  'extracts tags from Artifact Registry image JSON',
+);
+
+console.log('latest image resolver fixtures passed');

--- a/.github/workflows/internal-ci.yaml
+++ b/.github/workflows/internal-ci.yaml
@@ -140,6 +140,10 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
+      - name: Test latest image tag resolver
+        run: |
+          node .github/scripts/tests/latest-image.test.js
+
       - name: Test image reference resolver
         run: |
           node .github/scripts/tests/image-ref-resolution.test.js

--- a/.github/workflows/p2p-get-latest-image.yaml
+++ b/.github/workflows/p2p-get-latest-image.yaml
@@ -85,6 +85,20 @@ jobs:
           token_format: access_token
           access_token_lifetime: 3600s
 
+      - name: Checkout P2P workflow sources
+        uses: actions/checkout@v6
+        with:
+          repository: ${{ job.workflow_repository }}
+          ref: ${{ job.workflow_sha }}
+          path: .p2p-workflow-src
+
+      - name: Move P2P workflow sources outside app workspace
+        shell: bash
+        run: |
+          set -euo pipefail
+          rm -rf "$RUNNER_TEMP/p2p-workflow-src"
+          mv .p2p-workflow-src "$RUNNER_TEMP/p2p-workflow-src"
+
       - name: Get latest image
         id: get-latest-image
         env:
@@ -92,26 +106,7 @@ jobs:
         run: |
             set -o pipefail
             if [ "$DRY_RUN" == false ]; then
-              if ! version=$(gcloud artifacts docker images list "${REGISTRY}/${REGISTRY_PATH}/${IMAGE_NAME}" --include-tags --sort-by=~buildTime --format=json 2>/dev/null | jq -r '.[].tags[]' | jq -Rrn '[inputs] | sort_by(
-                # extract name and version
-                match("[0-9]+[0-9.]*";"").offset as $version_index
-                | .[:$version_index] as $name
-                | .[$version_index:]
-                # ignore build
-                | split("+")[0]
-                # extract version core and pre-release as arrays of numbers and strings
-                | split("-")
-                | (.[0] | split(".") | map(tonumber? // .)) as $version_core
-                | (.[1:] | join("-") | split(".") | map(tonumber? // .)) as $pre_release
-                # sort by name
-                | $name,
-                # sort by version core
-                $version_core,
-                # pre-release versions have a lower precedence than the associated normal version
-                ($pre_release | length)==0,
-                # sort by pre-release
-                $pre_release
-              ) | reverse | .[0]'); then
+              if ! version=$(gcloud artifacts docker images list "${REGISTRY}/${REGISTRY_PATH}/${IMAGE_NAME}" --include-tags --sort-by=~buildTime --format=json 2>/dev/null | node "$RUNNER_TEMP/p2p-workflow-src/.github/scripts/latest-image.js"); then
                 echo "exiting"
                 exit 1
               fi

--- a/docs/reference/p2p-get-latest-image.md
+++ b/docs/reference/p2p-get-latest-image.md
@@ -45,13 +45,14 @@ jobs:
 | `version` | The highest semver-sorted image tag found in the registry, `0.0.0` when `dry-run` is `true`, or empty when no tags are found. |
 | `found` | `true` when a tag was found, or when `dry-run` is `true`; `false` when the registry query succeeds but no tags are available. |
 
-## Semver sorting logic
+## SemVer sorting logic
 
-The workflow calls `gcloud artifacts docker images list` for `<registry>/<registry-path>/<image-name>`, retrieves all tags, and sorts them using a `jq` expression that:
+The workflow calls `gcloud artifacts docker images list` for `<registry>/<registry-path>/<image-name>`, retrieves all tags, and sorts them using the shared latest-image resolver. The resolver:
 
-1. Extracts the version core (e.g. `1.2.3`) and pre-release identifier (e.g. `alpha.1`) from each tag.
-2. Sorts first by name prefix, then by numeric version core components, then by whether a pre-release suffix is present (release versions rank above pre-release), then by the pre-release components.
-3. Reverses the sort and returns the first (highest) entry.
+1. Parses SemVer tags with an optional leading `v`, such as `1.2.3`, `v1.2.3`, and `1.2.3-alpha.1`.
+2. Compares tags by the normalized SemVer value, ignoring build metadata for precedence.
+3. Ranks release versions above pre-release versions for the same version core.
+4. Returns the original selected tag, preserving whether the registry tag used a leading `v`.
 
 ## See also
 


### PR DESCRIPTION
## Summary
- Extract the scheduled security scan latest-image tag selection into `.github/scripts/latest-image.js`.
- Normalize an optional leading `v` before SemVer comparison while returning the original selected tag.
- Add resolver fixtures covering `0.0.204` vs `0.0.204-<sha>` vs stale `v0.0.5`, original-tag preservation, prerelease ordering, build metadata ties, and Artifact Registry JSON input.
- Wire `p2p-get-latest-image.yaml` to use the shared resolver and document the behavior.

## Root cause
The scheduled security scan path uses `p2p-get-latest-image.yaml` to resolve an anchor image tag from Artifact Registry. Its previous inline jq expression sorted by the prefix before the first numeric version component before sorting by the version. Because the prefix `v` sorts after an empty prefix and the result was reversed, a stale legacy tag like `v0.0.5` could be selected over the current `0.0.204` tag.

This affected the support-bot scheduled security scan:
- Failed run: https://github.com/coreeng/support-bot/actions/runs/28004157605
- Failed job: https://github.com/coreeng/support-bot/actions/runs/28004157605/job/82882575354

Fast Feedback versioning is unaffected because `p2p-version` reads Git tags directly and produced image version `0.0.204` in the comparison run:
- Example job: https://github.com/coreeng/support-bot/actions/runs/27950028308/job/82712228261

## Validation
- `node .github/scripts/tests/latest-image.test.js`
- `node .github/scripts/tests/image-ref-resolution.test.js`
- `printf ... | node .github/scripts/latest-image.js` fixture returned `0.0.204`
- `actionlint -config-file .github/actionlint.yaml .github/workflows/p2p-get-latest-image.yaml .github/workflows/internal-ci.yaml`

Note: full `actionlint -config-file .github/actionlint.yaml` still reports pre-existing shellcheck findings in unrelated version/CD workflows.