### PR TITLE
[codex] Add directory-scoped source security ignores

### DIFF
--- a/.github/scripts/image-scan-helpers.js
+++ b/.github/scripts/image-scan-helpers.js
@@ -32,6 +32,31 @@ function splitEntries(output) {
   return String(output || '').trim().split(/[\s,]+/).filter(Boolean);
 }
 
+function isPathInsideOrEqual(candidate, base) {
+  const relative = path.relative(base, candidate);
+  return relative === '' || (!relative.startsWith('..') && !path.isAbsolute(relative));
+}
+
+function resolveWorkingDirectory(env, core, fsImpl = fs) {
+  const workingDirectory = env.WORKING_DIR || '.';
+  if (!env.GITHUB_WORKSPACE) return workingDirectory;
+  const workspace = path.resolve(env.GITHUB_WORKSPACE);
+  const resolved = path.resolve(workspace, workingDirectory);
+  if (!isPathInsideOrEqual(resolved, workspace)) {
+    core.setFailed('working-directory must resolve inside GITHUB_WORKSPACE');
+    return null;
+  }
+  if (fsImpl.existsSync(resolved)) {
+    const realWorkspace = fsImpl.realpathSync(workspace);
+    const realResolved = fsImpl.realpathSync(resolved);
+    if (!isPathInsideOrEqual(realResolved, realWorkspace)) {
+      core.setFailed('working-directory must resolve inside GITHUB_WORKSPACE');
+      return null;
+    }
+  }
+  return resolved;
+}
+
 async function resolveImages({
   core,
   env = process.env,
@@ -39,18 +64,20 @@ async function resolveImages({
 } = {}) {
   const stage = env.PIPELINE_STAGE;
   if (!validateStage(stage, core)) return;
+  const workingDirectory = resolveWorkingDirectory(env, core);
+  if (!workingDirectory) return;
 
   function runMake(target) {
     return execFileSyncImpl('make', ['--no-print-directory', target], {
       encoding: 'utf8',
-      cwd: env.WORKING_DIR,
+      cwd: workingDirectory,
     });
   }
 
   function makeTargetExists(target) {
     try {
       execFileSyncImpl('make', ['--no-print-directory', '-q', target], {
-        cwd: env.WORKING_DIR,
+        cwd: workingDirectory,
         stdio: 'ignore',
       });
       return true;

--- a/.github/scripts/image-security-report.js
+++ b/.github/scripts/image-security-report.js
@@ -112,7 +112,7 @@ const sameReportKeys = (left, right) => (
 const buildImageSecurityReport = async ({ core, env = process.env } = {}) => {
   const securityIgnoreHelper = env.P2P_SECURITY_IGNORE_HELPER || path.join(__dirname, 'p2p-security-ignore.js');
   const {
-    loadSecurityIgnore,
+    loadImageSecurityIgnore,
     splitImageVulnerabilities,
     splitImageSecrets,
     p2pRedactedSecretId,
@@ -123,7 +123,7 @@ const buildImageSecurityReport = async ({ core, env = process.env } = {}) => {
   const zeroScanTargets = env.SCAN_TARGET_COUNT === '0';
   const listExists = !!(list && fs.existsSync(list) && fs.statSync(list).size > 0);
   const runUrl = `${env.GITHUB_SERVER_URL}/${env.GITHUB_REPOSITORY}/actions/runs/${env.GITHUB_RUN_ID}`;
-  const securityIgnore = loadSecurityIgnore(env.GITHUB_WORKSPACE);
+  const securityIgnore = loadImageSecurityIgnore(env.GITHUB_WORKSPACE, env.WORKING_DIR);
 
   const shortNameFromRef = ref => {
     const refWithoutDigest = String(ref || '').split('@')[0];

--- a/.github/scripts/p2p-security-ignore.js
+++ b/.github/scripts/p2p-security-ignore.js
@@ -16,6 +16,17 @@ const assertString = (value, label) => {
   if (typeof value !== 'string' || value.trim() === '') throw new Error(`${label} must be a non-empty string`);
 };
 
+const toPosixPath = value => String(value || '').split(path.sep).join('/');
+const normalizeRelativePath = value => {
+  const normalized = toPosixPath(path.normalize(String(value || ''))).replace(/^\.\//, '');
+  return normalized === '.' ? '' : normalized;
+};
+
+const isPathInsideOrEqual = (candidate, base) => {
+  const relative = path.relative(base, candidate);
+  return relative === '' || (!relative.startsWith('..') && !path.isAbsolute(relative));
+};
+
 const assertExpiry = (value, label) => {
   if (value === undefined) return;
   assertString(value, label);
@@ -34,7 +45,17 @@ const validateIgnoreEntryBase = (entry, label, allowed) => {
   assertExpiry(entry.expires, `${label}.expires`);
 };
 
-const validateSecurityIgnore = parsed => {
+const sourcePathFilter = (value, label, options) => {
+  assertString(value, label);
+  if (!options.sourcePathBase || !options.sourcePathRoot) return value;
+  const resolved = path.resolve(options.sourcePathBase, value);
+  if (!isPathInsideOrEqual(resolved, options.sourcePathBase)) {
+    throw new Error(`${label} must not resolve outside the ignore file directory`);
+  }
+  return normalizeRelativePath(path.relative(options.sourcePathRoot, resolved));
+};
+
+const validateSecurityIgnore = (parsed, options = {}) => {
   if (!isPlainObject(parsed)) throw new Error('ignore file must be a YAML object');
   assertKeys(parsed, ['version', 'source', 'images'], 'ignore file');
   if (parsed.version !== 1) throw new Error('ignore file version must be 1');
@@ -75,28 +96,34 @@ const validateSecurityIgnore = parsed => {
   const secrets = source.secrets === undefined ? [] : source.secrets;
   if (!Array.isArray(vulnerabilities)) throw new Error('source.vulnerabilities must be a list');
   if (!Array.isArray(secrets)) throw new Error('source.secrets must be a list');
+  const normalizedVulnerabilities = [];
   for (const [index, entry] of vulnerabilities.entries()) {
     const label = `source.vulnerabilities[${index}]`;
     validateIgnoreEntryBase(entry, label, ['id', 'reason', 'package', 'paths', 'expires']);
     if (entry.package !== undefined) assertString(entry.package, `${label}.package`);
+    let normalizedPaths;
     if (entry.paths !== undefined) {
       if (!Array.isArray(entry.paths)) throw new Error(`${label}.paths must be a list`);
-      for (const [pathIndex, item] of entry.paths.entries()) assertString(item, `${label}.paths[${pathIndex}]`);
+      normalizedPaths = entry.paths.map((item, pathIndex) => sourcePathFilter(item, `${label}.paths[${pathIndex}]`, options));
     }
+    normalizedVulnerabilities.push({
+      ...entry,
+      ...(normalizedPaths === undefined ? {} : { paths: normalizedPaths }),
+    });
   }
+  const normalizedSecrets = [];
   for (const [index, entry] of secrets.entries()) {
     const label = `source.secrets[${index}]`;
     validateIgnoreEntryBase(entry, label, ['id', 'reason', 'path', 'expires']);
-    if (entry.path !== undefined) assertString(entry.path, `${label}.path`);
+    normalizedSecrets.push({
+      ...entry,
+      ...(entry.path === undefined ? {} : { path: sourcePathFilter(entry.path, `${label}.path`, options) }),
+    });
   }
-  return { images: normalizedImages, source: { vulnerabilities, secrets } };
+  return { images: normalizedImages, source: { vulnerabilities: normalizedVulnerabilities, secrets: normalizedSecrets } };
 };
 
-const loadSecurityIgnore = workspace => {
-  const ignorePath = path.join(workspace || '', '.p2p-security-ignore.yaml');
-  if (!workspace || !fs.existsSync(ignorePath)) {
-    return { present: false, images: [], source: { vulnerabilities: [], secrets: [] } };
-  }
+const parseSecurityIgnoreFile = (ignorePath, options = {}) => {
   let parsed;
   try {
     parsed = JSON.parse(execFileSync(
@@ -108,10 +135,82 @@ const loadSecurityIgnore = workspace => {
     throw new Error(`Invalid .p2p-security-ignore.yaml: ${error.stderr || error.message}`);
   }
   try {
-    return { present: true, ...validateSecurityIgnore(parsed) };
+    return validateSecurityIgnore(parsed, options);
   } catch (error) {
     throw new Error(`Invalid .p2p-security-ignore.yaml: ${error.message}`);
   }
+};
+
+const emptySecurityIgnore = () => ({ present: false, images: [], source: { vulnerabilities: [], secrets: [] } });
+
+const loadSecurityIgnore = workspace => {
+  const ignorePath = path.join(workspace || '', '.p2p-security-ignore.yaml');
+  if (!workspace || !fs.existsSync(ignorePath)) {
+    return emptySecurityIgnore();
+  }
+  return { present: true, ...parseSecurityIgnoreFile(ignorePath) };
+};
+
+const mergeSecurityIgnores = ignores => ({
+  present: ignores.some(ignore => ignore.present),
+  images: ignores.flatMap(ignore => ignore.images),
+  source: {
+    vulnerabilities: ignores.flatMap(ignore => ignore.source.vulnerabilities),
+    secrets: ignores.flatMap(ignore => ignore.source.secrets),
+  },
+});
+
+const loadImageSecurityIgnore = (workspace, workingDirectory = '') => {
+  const rootIgnore = loadSecurityIgnore(workspace);
+  const selectedDirectory = path.resolve(workspace || '', workingDirectory || '.');
+  if (!workspace || selectedDirectory === path.resolve(workspace)) return rootIgnore;
+
+  const selectedIgnorePath = path.join(selectedDirectory, '.p2p-security-ignore.yaml');
+  if (!fs.existsSync(selectedIgnorePath)) return rootIgnore;
+
+  return mergeSecurityIgnores([
+    rootIgnore,
+    { present: true, ...parseSecurityIgnoreFile(selectedIgnorePath) },
+  ]);
+};
+
+const discoverSourceIgnoreFiles = workspace => {
+  if (!workspace || !fs.existsSync(workspace)) return [];
+  const ignoreFiles = [];
+  const visit = directory => {
+    for (const dirent of fs.readdirSync(directory, { withFileTypes: true })) {
+      const fullPath = path.join(directory, dirent.name);
+      if (dirent.isDirectory()) {
+        if (dirent.name !== '.git') visit(fullPath);
+      } else if (dirent.isFile() && dirent.name === '.p2p-security-ignore.yaml') {
+        ignoreFiles.push(fullPath);
+      }
+    }
+  };
+  visit(workspace);
+  return ignoreFiles.sort((a, b) => a.localeCompare(b));
+};
+
+const loadSourceSecurityIgnores = workspace => {
+  const files = discoverSourceIgnoreFiles(workspace);
+  if (files.length === 0) {
+    return { present: false, sourceIgnores: [] };
+  }
+
+  return {
+    present: true,
+    sourceIgnores: files.map(file => {
+      const directory = path.dirname(file);
+      const parsed = parseSecurityIgnoreFile(file, {
+        sourcePathRoot: workspace,
+        sourcePathBase: directory,
+      });
+      return {
+        directory: normalizeRelativePath(path.relative(workspace, directory)),
+        source: parsed.source,
+      };
+    }),
+  };
 };
 
 const activeIgnore = entry => entry.expires === undefined || entry.expires >= todayIso();
@@ -121,39 +220,68 @@ const p2pRedactedSecretId = value => {
   return `p2psec_${fingerprint}`;
 };
 
-const findSourceVulnerabilityIgnore = (finding, ignore) => ignore.source.vulnerabilities.find(entry => (
-  activeIgnore(entry)
-  && entry.id === finding.id
-  && (entry.package === undefined || entry.package === finding.package)
-  && (entry.paths === undefined || entry.paths.includes(finding.source))
-));
+const sourceScopes = ignore => {
+  if (Array.isArray(ignore.sourceIgnores)) return ignore.sourceIgnores;
+  return [{ directory: '', source: ignore.source }];
+};
 
-const findSourceSecretIgnore = (finding, ignore) => ignore.source.secrets.find(entry => (
-  activeIgnore(entry)
-  && entry.id === finding.id
-  && (entry.path === undefined || entry.path === finding.file)
-));
+const sourceFindingPath = finding => normalizeRelativePath(finding.source || finding.file || '');
 
-const findImage = (ignore, imageName) => ignore.images.find(image => image.name === imageName);
+const sourceFindingInScope = (finding, scopedIgnore) => {
+  if (!scopedIgnore.directory) return true;
+  const findingPath = sourceFindingPath(finding);
+  return findingPath === scopedIgnore.directory || findingPath.startsWith(`${scopedIgnore.directory}/`);
+};
+
+const findSourceVulnerabilityIgnore = (finding, ignore) => {
+  for (const scopedIgnore of sourceScopes(ignore)) {
+    if (!sourceFindingInScope(finding, scopedIgnore)) continue;
+    const matched = scopedIgnore.source.vulnerabilities.find(entry => (
+      activeIgnore(entry)
+      && entry.id === finding.id
+      && (entry.package === undefined || entry.package === finding.package)
+      && (entry.paths === undefined || entry.paths.includes(sourceFindingPath(finding)))
+    ));
+    if (matched) return matched;
+  }
+  return undefined;
+};
+
+const findSourceSecretIgnore = (finding, ignore) => {
+  for (const scopedIgnore of sourceScopes(ignore)) {
+    if (!sourceFindingInScope(finding, scopedIgnore)) continue;
+    const matched = scopedIgnore.source.secrets.find(entry => (
+      activeIgnore(entry)
+      && entry.id === finding.id
+      && (entry.path === undefined || entry.path === sourceFindingPath(finding))
+    ));
+    if (matched) return matched;
+  }
+  return undefined;
+};
 
 const findImageVulnerabilityIgnore = (finding, ignore, imageName) => {
-  const image = findImage(ignore, imageName);
-  if (!image) return undefined;
-  return image.vulnerabilities.find(entry => (
-    activeIgnore(entry)
-    && entry.id === finding.id
-    && (entry.package === undefined || entry.package === finding.package)
-  ));
+  for (const image of ignore.images.filter(item => item.name === imageName)) {
+    const matched = image.vulnerabilities.find(entry => (
+      activeIgnore(entry)
+      && entry.id === finding.id
+      && (entry.package === undefined || entry.package === finding.package)
+    ));
+    if (matched) return matched;
+  }
+  return undefined;
 };
 
 const findImageSecretIgnore = (finding, ignore, imageName) => {
-  const image = findImage(ignore, imageName);
-  if (!image) return undefined;
-  return image.secrets.find(entry => (
-    activeIgnore(entry)
-    && entry.id === finding.id
-    && (entry.path === undefined || entry.path === finding.path)
-  ));
+  for (const image of ignore.images.filter(item => item.name === imageName)) {
+    const matched = image.secrets.find(entry => (
+      activeIgnore(entry)
+      && entry.id === finding.id
+      && (entry.path === undefined || entry.path === finding.path)
+    ));
+    if (matched) return matched;
+  }
+  return undefined;
 };
 
 const ignoreMetadata = entry => ({
@@ -193,6 +321,8 @@ const splitImageSecrets = (findings, ignore, imageName) => (
 
 module.exports = {
   loadSecurityIgnore,
+  loadImageSecurityIgnore,
+  loadSourceSecurityIgnores,
   splitSourceVulnerabilities,
   splitSourceSecrets,
   splitImageVulnerabilities,

--- a/.github/scripts/p2p-security-ignore.js
+++ b/.github/scripts/p2p-security-ignore.js
@@ -27,6 +27,24 @@ const isPathInsideOrEqual = (candidate, base) => {
   return relative === '' || (!relative.startsWith('..') && !path.isAbsolute(relative));
 };
 
+const nearestExistingPath = value => {
+  let current = value;
+  while (!fs.existsSync(current)) {
+    const parent = path.dirname(current);
+    if (parent === current) return null;
+    current = parent;
+  }
+  return current;
+};
+
+const assertRealPathInsideOrEqual = (candidate, base, message) => {
+  const existingCandidate = nearestExistingPath(candidate);
+  if (!existingCandidate) return;
+  const realBase = fs.realpathSync(base);
+  const realCandidate = fs.realpathSync(existingCandidate);
+  if (!isPathInsideOrEqual(realCandidate, realBase)) throw new Error(message);
+};
+
 const assertExpiry = (value, label) => {
   if (value === undefined) return;
   assertString(value, label);
@@ -49,9 +67,11 @@ const sourcePathFilter = (value, label, options) => {
   assertString(value, label);
   if (!options.sourcePathBase || !options.sourcePathRoot) return value;
   const resolved = path.resolve(options.sourcePathBase, value);
+  const escapeMessage = `${label} must not resolve outside the ignore file directory`;
   if (!isPathInsideOrEqual(resolved, options.sourcePathBase)) {
-    throw new Error(`${label} must not resolve outside the ignore file directory`);
+    throw new Error(escapeMessage);
   }
+  assertRealPathInsideOrEqual(resolved, options.sourcePathBase, escapeMessage);
   return normalizeRelativePath(path.relative(options.sourcePathRoot, resolved));
 };
 
@@ -168,13 +188,11 @@ const loadImageSecurityIgnore = (workspace, workingDirectory = '') => {
   if (!isPathInsideOrEqual(selectedDirectory, rootDirectory)) {
     throw new Error('working-directory must resolve inside GITHUB_WORKSPACE');
   }
-  if (fs.existsSync(selectedDirectory)) {
-    const realRootDirectory = fs.realpathSync(rootDirectory);
-    const realSelectedDirectory = fs.realpathSync(selectedDirectory);
-    if (!isPathInsideOrEqual(realSelectedDirectory, realRootDirectory)) {
-      throw new Error('working-directory must resolve inside GITHUB_WORKSPACE');
-    }
-  }
+  assertRealPathInsideOrEqual(
+    selectedDirectory,
+    rootDirectory,
+    'working-directory must resolve inside GITHUB_WORKSPACE',
+  );
   if (selectedDirectory === rootDirectory) return rootIgnore;
 
   const selectedIgnorePath = path.join(selectedDirectory, '.p2p-security-ignore.yaml');

--- a/.github/scripts/p2p-security-ignore.js
+++ b/.github/scripts/p2p-security-ignore.js
@@ -168,6 +168,13 @@ const loadImageSecurityIgnore = (workspace, workingDirectory = '') => {
   if (!isPathInsideOrEqual(selectedDirectory, rootDirectory)) {
     throw new Error('working-directory must resolve inside GITHUB_WORKSPACE');
   }
+  if (fs.existsSync(selectedDirectory)) {
+    const realRootDirectory = fs.realpathSync(rootDirectory);
+    const realSelectedDirectory = fs.realpathSync(selectedDirectory);
+    if (!isPathInsideOrEqual(realSelectedDirectory, realRootDirectory)) {
+      throw new Error('working-directory must resolve inside GITHUB_WORKSPACE');
+    }
+  }
   if (selectedDirectory === rootDirectory) return rootIgnore;
 
   const selectedIgnorePath = path.join(selectedDirectory, '.p2p-security-ignore.yaml');

--- a/.github/scripts/p2p-security-ignore.js
+++ b/.github/scripts/p2p-security-ignore.js
@@ -162,8 +162,13 @@ const mergeSecurityIgnores = ignores => ({
 
 const loadImageSecurityIgnore = (workspace, workingDirectory = '') => {
   const rootIgnore = loadSecurityIgnore(workspace);
-  const selectedDirectory = path.resolve(workspace || '', workingDirectory || '.');
-  if (!workspace || selectedDirectory === path.resolve(workspace)) return rootIgnore;
+  if (!workspace) return rootIgnore;
+  const rootDirectory = path.resolve(workspace);
+  const selectedDirectory = path.resolve(rootDirectory, workingDirectory || '.');
+  if (!isPathInsideOrEqual(selectedDirectory, rootDirectory)) {
+    throw new Error('working-directory must resolve inside GITHUB_WORKSPACE');
+  }
+  if (selectedDirectory === rootDirectory) return rootIgnore;
 
   const selectedIgnorePath = path.join(selectedDirectory, '.p2p-security-ignore.yaml');
   if (!fs.existsSync(selectedIgnorePath)) return rootIgnore;

--- a/.github/scripts/source-security-report.js
+++ b/.github/scripts/source-security-report.js
@@ -124,7 +124,7 @@ const maxSecurityRisk = (vulnerabilities, secrets) => {
 const buildSourceSecurityReport = async ({ core, env = process.env } = {}) => {
 const securityIgnoreHelper = env.P2P_SECURITY_IGNORE_HELPER || path.join(__dirname, 'p2p-security-ignore.js');
 const {
-  loadSecurityIgnore,
+  loadSourceSecurityIgnores,
   splitSourceVulnerabilities,
   splitSourceSecrets,
 } = require(securityIgnoreHelper);
@@ -152,7 +152,7 @@ if (!dryRun) {
 const reportSeveritySet = severitySet('LOW,MEDIUM,HIGH,CRITICAL,UNKNOWN');
 const blockingSet = blockingSeveritySet(env.BLOCKING_SEVERITY, core);
 const reportedSeverities = ['CRITICAL', 'HIGH', 'MEDIUM', 'LOW', 'UNKNOWN'];
-const securityIgnore = loadSecurityIgnore(env.GITHUB_WORKSPACE);
+const securityIgnore = loadSourceSecurityIgnores(env.GITHUB_WORKSPACE);
 const trivy = !dryRun && env.SCA_SCAN_RESULT === 'success'
   ? readRequiredJson(trivyPath, 'Trivy source report')
   : readJson(trivyPath, { Results: [] });

--- a/.github/scripts/tests/image-ref-resolution.test.js
+++ b/.github/scripts/tests/image-ref-resolution.test.js
@@ -1,4 +1,7 @@
 const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
 const { resolveImages } = require('../image-scan-helpers');
 
 async function runCase(name, makeOutputs, envOverrides = {}) {
@@ -16,6 +19,7 @@ async function runCase(name, makeOutputs, envOverrides = {}) {
       TENANT_NAME: 'tenant-a',
       VERSION: '1.2.3',
       WORKING_DIR: '/repo',
+      GITHUB_WORKSPACE: '/repo',
       ...envOverrides,
     },
     core: {
@@ -102,6 +106,40 @@ async function runCase(name, makeOutputs, envOverrides = {}) {
   );
   assert.strictEqual(unknownStage.outputs['image-refs'], undefined);
   assert.deepStrictEqual(unknownStage.calls, [], 'unknown stage fails before make');
+
+  const escapedWorkingDirectory = await runCase(
+    'working-directory escape fails before image resolution',
+    { 'p2p-images': 'api\n' },
+    { WORKING_DIR: '../outside', IMAGE_NAMES: 'api' },
+  );
+  assert.deepStrictEqual(
+    escapedWorkingDirectory.failures,
+    ['working-directory must resolve inside GITHUB_WORKSPACE'],
+  );
+  assert.strictEqual(escapedWorkingDirectory.outputs['image-refs'], undefined);
+  assert.deepStrictEqual(escapedWorkingDirectory.calls, [], 'working-directory escape fails before make');
+
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'image-ref-working-dir-'));
+  const workspace = path.join(tmp, 'repo');
+  const outside = path.join(tmp, 'outside');
+  fs.mkdirSync(workspace, { recursive: true });
+  fs.mkdirSync(outside, { recursive: true });
+  try {
+    fs.symlinkSync(outside, path.join(workspace, 'link'), 'dir');
+    const symlinkWorkingDirectory = await runCase(
+      'working-directory symlink escape fails before image resolution',
+      { 'p2p-images': 'api\n' },
+      { GITHUB_WORKSPACE: workspace, WORKING_DIR: 'link', IMAGE_NAMES: 'api' },
+    );
+    assert.deepStrictEqual(
+      symlinkWorkingDirectory.failures,
+      ['working-directory must resolve inside GITHUB_WORKSPACE'],
+    );
+    assert.strictEqual(symlinkWorkingDirectory.outputs['image-refs'], undefined);
+    assert.deepStrictEqual(symlinkWorkingDirectory.calls, [], 'working-directory symlink escape fails before make');
+  } catch (error) {
+    if (error.code !== 'EPERM' && error.code !== 'EACCES') throw error;
+  }
 
   console.log('image ref resolver fixtures passed');
 })().catch(error => {

--- a/.github/scripts/tests/image-security-ignore-report.test.js
+++ b/.github/scripts/tests/image-security-ignore-report.test.js
@@ -349,6 +349,56 @@ async function runWorkingDirectoryImageIgnoreReport() {
   });
 }
 
+async function runEscapingWorkingDirectoryImageReport() {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'image-working-directory-escape-'));
+  const workspace = path.join(tmp, 'repo');
+  const outside = path.join(tmp, 'outside');
+  fs.mkdirSync(workspace, { recursive: true });
+  fs.mkdirSync(outside, { recursive: true });
+  fs.writeFileSync(path.join(outside, '.p2p-security-ignore.yaml'), [
+    'version: 1',
+    'images:',
+    '  - name: api',
+    '    vulnerabilities:',
+    '      - id: CVE-OUTSIDE-IMAGE',
+    '        reason: Outside repo ignore must not be loaded.',
+    '',
+  ].join('\n'));
+
+  await buildImageSecurityReport({
+    env: {
+      RUNNER_TEMP: tmp,
+      GITHUB_WORKSPACE: workspace,
+      WORKING_DIR: '../outside',
+      BLOCKING_SEVERITY: 'high',
+      PIPELINE_STAGE: 'prod',
+      GITHUB_ENV_INPUT: '',
+      VERSION: '1.2.3',
+      REGION: 'europe-west2',
+      PROJECT_ID: 'project',
+      TENANT_NAME: 'prod',
+      P2P_SECURITY_IGNORE_HELPER: helperPath,
+      GITHUB_SERVER_URL: 'https://github.example',
+      GITHUB_REPOSITORY: 'org/repo',
+      GITHUB_RUN_ID: '42',
+    },
+    core: {
+      setOutput: () => {},
+      setFailed: () => {},
+      info: () => {},
+      warning: () => {},
+      summary: {
+        addRaw() {
+          return this;
+        },
+        write() {
+          return Promise.resolve();
+        },
+      },
+    },
+  });
+}
+
 async function runUnclassifiedImageReport() {
   const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'image-unclassified-'));
   const workspace = path.join(tmp, 'repo');
@@ -1003,6 +1053,11 @@ async function runZeroScanTargetReport() {
       blocking: false,
     },
   ]);
+  await assert.rejects(
+    () => runEscapingWorkingDirectoryImageReport(),
+    error => error.message.includes('working-directory must resolve inside GITHUB_WORKSPACE'),
+    'image working-directory must not load ignore files outside the repository',
+  );
   const imageStatusSteps = readStatusStepNames(path.resolve(__dirname, '../../workflows/p2p-workflow-image-scan.yaml'));
   assert.deepStrictEqual(imageStatusSteps, [
     '      - name: "Output security risk: ${{ needs.security-image-scan.outputs.security-risk || \'unknown\' }}; scan: ${{ needs.security-image-scan.outputs.scan-status || \'failed\' }}"',

--- a/.github/scripts/tests/image-security-ignore-report.test.js
+++ b/.github/scripts/tests/image-security-ignore-report.test.js
@@ -255,6 +255,100 @@ async function runOffModeAllIgnoredReport() {
   });
 }
 
+async function runWorkingDirectoryImageIgnoreReport() {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'image-working-directory-ignore-'));
+  const workspace = path.join(tmp, 'repo');
+  const trivyDir = path.join(tmp, 'trivy');
+  const secretDir = path.join(tmp, 'trufflehog-image');
+  fs.mkdirSync(path.join(workspace, 'services', 'api'), { recursive: true });
+  fs.mkdirSync(path.join(workspace, 'services', 'other'), { recursive: true });
+  fs.mkdirSync(trivyDir, { recursive: true });
+  fs.mkdirSync(secretDir, { recursive: true });
+  fs.writeFileSync(path.join(workspace, '.p2p-security-ignore.yaml'), [
+    'version: 1',
+    'images:',
+    '  - name: api',
+    '    vulnerabilities:',
+    '      - id: CVE-ROOT-IMAGE',
+    '        reason: Root image risk.',
+    '',
+  ].join('\n'));
+  fs.writeFileSync(path.join(workspace, 'services', 'api', '.p2p-security-ignore.yaml'), [
+    'version: 1',
+    'images:',
+    '  - name: api',
+    '    vulnerabilities:',
+    '      - id: CVE-SELECTED-IMAGE',
+    '        reason: Selected working-directory image risk.',
+    '    secrets:',
+    `      - id: ${secretId('selected-image-secret-value')}`,
+    '        reason: Selected working-directory image secret.',
+    '',
+  ].join('\n'));
+  fs.writeFileSync(path.join(workspace, 'services', 'other', '.p2p-security-ignore.yaml'), [
+    'version: 1',
+    'images:',
+    '  - name: api',
+    '    vulnerabilities:',
+    '      - id: CVE-UNSELECTED-IMAGE',
+    '        reason: Unselected image risk.',
+    '',
+  ].join('\n'));
+
+  const vulnReport = path.join(trivyDir, 'api-vuln.json');
+  fs.writeFileSync(vulnReport, JSON.stringify({
+    Results: [
+      {
+        Target: 'api-image (debian)',
+        Vulnerabilities: [
+          { VulnerabilityID: 'CVE-ROOT-IMAGE', PkgName: 'root-lib', Severity: 'HIGH', PrimaryURL: 'https://example.test/CVE-ROOT-IMAGE' },
+          { VulnerabilityID: 'CVE-SELECTED-IMAGE', PkgName: 'selected-lib', Severity: 'HIGH', PrimaryURL: 'https://example.test/CVE-SELECTED-IMAGE' },
+          { VulnerabilityID: 'CVE-UNSELECTED-IMAGE', PkgName: 'unselected-lib', Severity: 'HIGH', PrimaryURL: 'https://example.test/CVE-UNSELECTED-IMAGE' },
+        ],
+      },
+    ],
+  }));
+  const reportList = path.join(trivyDir, 'reports.txt');
+  fs.writeFileSync(reportList, [
+    `europe-west2-docker.pkg.dev/project/tenant/prod/prod/api:1.2.3\tlinux/amd64\tsha256:api\t${vulnReport}`,
+    '',
+  ].join('\n'));
+
+  const secretReport = path.join(secretDir, 'api-secret.jsonl');
+  fs.writeFileSync(secretReport, [
+    JSON.stringify({
+      DetectorName: 'Github',
+      Verified: true,
+      Raw: 'selected-image-secret-value',
+      SourceMetadata: { Data: { Docker: { layer: 'sha256:layer1', file: '/app/selected.env' } } },
+    }),
+  ].join('\n') + '\n');
+  const secretList = path.join(secretDir, 'reports.txt');
+  fs.writeFileSync(secretList, [
+    `europe-west2-docker.pkg.dev/project/tenant/prod/prod/api:1.2.3\tlinux/amd64\tsha256:api\t${secretReport}`,
+    '',
+  ].join('\n'));
+
+  return runReportModule({
+    RUNNER_TEMP: tmp,
+    GITHUB_WORKSPACE: workspace,
+    WORKING_DIR: 'services/api',
+    REPORT_LIST: reportList,
+    SECRET_REPORT_LIST: secretList,
+    BLOCKING_SEVERITY: 'high',
+    PIPELINE_STAGE: 'prod',
+    GITHUB_ENV_INPUT: '',
+    VERSION: '1.2.3',
+    REGION: 'europe-west2',
+    PROJECT_ID: 'project',
+    TENANT_NAME: 'prod',
+    P2P_SECURITY_IGNORE_HELPER: helperPath,
+    GITHUB_SERVER_URL: 'https://github.example',
+    GITHUB_REPOSITORY: 'org/repo',
+    GITHUB_RUN_ID: '42',
+  });
+}
+
 async function runUnclassifiedImageReport() {
   const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'image-unclassified-'));
   const workspace = path.join(tmp, 'repo');
@@ -877,6 +971,38 @@ async function runZeroScanTargetReport() {
   assert(!offMode.summary.includes('### Ignored image findings'));
   assert(!offMode.summary.includes('Accepted off-mode image vulnerability.'));
   assert(!offMode.summary.includes('Accepted off-mode image secret.'));
+
+  const workingDirectoryIgnores = await runWorkingDirectoryImageIgnoreReport();
+  assert.deepStrictEqual(workingDirectoryIgnores.failures, []);
+  assert.strictEqual(workingDirectoryIgnores.outputs['total-count'], 1);
+  assert.strictEqual(workingDirectoryIgnores.outputs['blocking-count'], 1);
+  assert.strictEqual(workingDirectoryIgnores.outputs['secret-total-count'], 0);
+  assert.strictEqual(workingDirectoryIgnores.outputs['secret-blocking-count'], 0);
+  assert.deepStrictEqual(workingDirectoryIgnores.normalized.vulnerabilities.map(v => v.id), ['CVE-UNSELECTED-IMAGE']);
+  assert.deepStrictEqual(workingDirectoryIgnores.normalized.ignored.vulnerabilities.map(v => ({
+    id: v.id,
+    reason: v.ignore.reason,
+  })).sort((a, b) => a.id.localeCompare(b.id)), [
+    {
+      id: 'CVE-ROOT-IMAGE',
+      reason: 'Root image risk.',
+    },
+    {
+      id: 'CVE-SELECTED-IMAGE',
+      reason: 'Selected working-directory image risk.',
+    },
+  ]);
+  assert.deepStrictEqual(workingDirectoryIgnores.normalized.ignored.secrets.map(s => ({
+    id: s.id,
+    reason: s.ignore.reason,
+    blocking: s.isBlocking,
+  })), [
+    {
+      id: secretId('selected-image-secret-value'),
+      reason: 'Selected working-directory image secret.',
+      blocking: false,
+    },
+  ]);
   const imageStatusSteps = readStatusStepNames(path.resolve(__dirname, '../../workflows/p2p-workflow-image-scan.yaml'));
   assert.deepStrictEqual(imageStatusSteps, [
     '      - name: "Output security risk: ${{ needs.security-image-scan.outputs.security-risk || \'unknown\' }}; scan: ${{ needs.security-image-scan.outputs.scan-status || \'failed\' }}"',

--- a/.github/scripts/tests/image-security-ignore-report.test.js
+++ b/.github/scripts/tests/image-security-ignore-report.test.js
@@ -399,6 +399,57 @@ async function runEscapingWorkingDirectoryImageReport() {
   });
 }
 
+async function runSymlinkEscapingWorkingDirectoryImageReport() {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'image-working-directory-symlink-'));
+  const workspace = path.join(tmp, 'repo');
+  const outside = path.join(tmp, 'outside');
+  fs.mkdirSync(workspace, { recursive: true });
+  fs.mkdirSync(outside, { recursive: true });
+  fs.symlinkSync(outside, path.join(workspace, 'link'), 'dir');
+  fs.writeFileSync(path.join(outside, '.p2p-security-ignore.yaml'), [
+    'version: 1',
+    'images:',
+    '  - name: api',
+    '    vulnerabilities:',
+    '      - id: CVE-OUTSIDE-IMAGE',
+    '        reason: Outside repo ignore must not be loaded.',
+    '',
+  ].join('\n'));
+
+  await buildImageSecurityReport({
+    env: {
+      RUNNER_TEMP: tmp,
+      GITHUB_WORKSPACE: workspace,
+      WORKING_DIR: 'link',
+      BLOCKING_SEVERITY: 'high',
+      PIPELINE_STAGE: 'prod',
+      GITHUB_ENV_INPUT: '',
+      VERSION: '1.2.3',
+      REGION: 'europe-west2',
+      PROJECT_ID: 'project',
+      TENANT_NAME: 'prod',
+      P2P_SECURITY_IGNORE_HELPER: helperPath,
+      GITHUB_SERVER_URL: 'https://github.example',
+      GITHUB_REPOSITORY: 'org/repo',
+      GITHUB_RUN_ID: '42',
+    },
+    core: {
+      setOutput: () => {},
+      setFailed: () => {},
+      info: () => {},
+      warning: () => {},
+      summary: {
+        addRaw() {
+          return this;
+        },
+        write() {
+          return Promise.resolve();
+        },
+      },
+    },
+  });
+}
+
 async function runUnclassifiedImageReport() {
   const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'image-unclassified-'));
   const workspace = path.join(tmp, 'repo');
@@ -1058,6 +1109,15 @@ async function runZeroScanTargetReport() {
     error => error.message.includes('working-directory must resolve inside GITHUB_WORKSPACE'),
     'image working-directory must not load ignore files outside the repository',
   );
+  try {
+    await assert.rejects(
+      () => runSymlinkEscapingWorkingDirectoryImageReport(),
+      error => error.message.includes('working-directory must resolve inside GITHUB_WORKSPACE'),
+      'image working-directory must not follow symlinks outside the repository',
+    );
+  } catch (error) {
+    if (error.code !== 'EPERM' && error.code !== 'EACCES') throw error;
+  }
   const imageStatusSteps = readStatusStepNames(path.resolve(__dirname, '../../workflows/p2p-workflow-image-scan.yaml'));
   assert.deepStrictEqual(imageStatusSteps, [
     '      - name: "Output security risk: ${{ needs.security-image-scan.outputs.security-risk || \'unknown\' }}; scan: ${{ needs.security-image-scan.outputs.scan-status || \'failed\' }}"',

--- a/.github/scripts/tests/source-security-ignore-report.test.js
+++ b/.github/scripts/tests/source-security-ignore-report.test.js
@@ -784,6 +784,55 @@ async function runReportWithNestedInvalidIgnoreFile(ignoreFile, dryRun = false) 
   });
 }
 
+async function runReportWithNestedSymlinkEscapeIgnoreFile(ignoreFile) {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'source-nested-symlink-ignore-'));
+  const root = path.join(tmp, 'source-security');
+  const workspace = path.join(tmp, 'repo');
+  const api = path.join(workspace, 'services', 'api');
+  const outside = path.join(tmp, 'outside');
+  fs.mkdirSync(path.join(root, 'trivy'), { recursive: true });
+  fs.mkdirSync(path.join(root, 'trufflehog'), { recursive: true });
+  fs.mkdirSync(api, { recursive: true });
+  fs.mkdirSync(outside, { recursive: true });
+  fs.writeFileSync(path.join(outside, 'package-lock.json'), '{}');
+  fs.writeFileSync(path.join(outside, 'token.txt'), 'not-a-real-token');
+  fs.symlinkSync(outside, path.join(api, 'link'), 'dir');
+  fs.writeFileSync(path.join(api, '.p2p-security-ignore.yaml'), ignoreFile);
+  fs.writeFileSync(path.join(root, 'trivy', 'trivy-fs.json'), JSON.stringify({ Results: [] }));
+  fs.writeFileSync(path.join(root, 'trufflehog', 'findings.ndjson'), '');
+
+  await buildSourceSecurityReport({
+    env: {
+      ROOT: root,
+      GITHUB_WORKSPACE: workspace,
+      DRY_RUN: 'false',
+      BLOCKING_SEVERITY: 'high',
+      SCOPE: 'changes',
+      BASE: 'base-sha',
+      SECRET_SCAN_RESULT: 'success',
+      SCA_SCAN_RESULT: 'success',
+      P2P_SECURITY_IGNORE_HELPER: helperPath,
+      GITHUB_SERVER_URL: 'https://github.example',
+      GITHUB_REPOSITORY: 'org/repo',
+      GITHUB_RUN_ID: '42',
+    },
+    core: {
+      setOutput: () => {},
+      setFailed: () => {},
+      info: () => {},
+      warning: () => {},
+      summary: {
+        addRaw() {
+          return this;
+        },
+        write() {
+          return Promise.resolve();
+        },
+      },
+    },
+  });
+}
+
 async function runReportWithCorruptTruffleHogOutput() {
   const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'source-corrupt-secret-'));
   const root = path.join(tmp, 'source-security');
@@ -1132,6 +1181,20 @@ async function runReportWithMissingTruffleHogOutput() {
     error => error.message.includes('source.vulnerabilities[0].reason must be a non-empty string'),
     'dry-run validates discovered nested ignore files',
   );
+  for (const [name, ignoreFile, expected] of [
+    ['nested vulnerability symlink path escape', 'version: 1\nsource:\n  vulnerabilities:\n    - id: CVE-SYMLINK\n      reason: symlink escape\n      paths:\n        - link/package-lock.json\n', 'source.vulnerabilities[0].paths[0] must not resolve outside the ignore file directory'],
+    ['nested secret symlink path escape', 'version: 1\nsource:\n  secrets:\n    - id: symlink-secret\n      reason: symlink escape\n      path: link/token.txt\n', 'source.secrets[0].path must not resolve outside the ignore file directory'],
+  ]) {
+    try {
+      await assert.rejects(
+        () => runReportWithNestedSymlinkEscapeIgnoreFile(ignoreFile),
+        error => error.message.includes(expected),
+        name,
+      );
+    } catch (error) {
+      if (error.code !== 'EPERM' && error.code !== 'EACCES') throw error;
+    }
+  }
   await assert.rejects(
     () => runReportWithCorruptTruffleHogOutput(),
     error => error.message.includes('Failed to process TruffleHog source report'),

--- a/.github/scripts/tests/source-security-ignore-report.test.js
+++ b/.github/scripts/tests/source-security-ignore-report.test.js
@@ -643,6 +643,147 @@ async function runReportWithInvalidIgnoreFile(ignoreFile) {
   await buildSourceSecurityReport({ core: sandbox.core, env: sandbox.process.env });
 }
 
+async function runDirectoryScopedIgnoreReport() {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'source-directory-ignore-'));
+  const root = path.join(tmp, 'source-security');
+  const workspace = path.join(tmp, 'repo');
+  fs.mkdirSync(path.join(root, 'trivy'), { recursive: true });
+  fs.mkdirSync(path.join(root, 'trufflehog'), { recursive: true });
+  fs.mkdirSync(path.join(workspace, 'services', 'api'), { recursive: true });
+  fs.mkdirSync(path.join(workspace, 'services', 'web'), { recursive: true });
+  fs.writeFileSync(path.join(workspace, '.p2p-security-ignore.yaml'), [
+    'version: 1',
+    'source:',
+    '  vulnerabilities:',
+    '    - id: CVE-ROOT-PATH',
+    '      reason: Root path-scoped risk.',
+    '      paths:',
+    '        - services/web/package-lock.json',
+    '  secrets:',
+    '    - id: root-secret',
+    '      reason: Root source secret.',
+    '',
+  ].join('\n'));
+  fs.writeFileSync(path.join(workspace, 'services', 'api', '.p2p-security-ignore.yaml'), [
+    'version: 1',
+    'source:',
+    '  vulnerabilities:',
+    '    - id: CVE-LOCAL-PATH',
+    '      reason: API-local dependency risk.',
+    '      paths:',
+    '        - package-lock.json',
+    '  secrets:',
+    '    - id: local-secret',
+    '      reason: API-local source secret.',
+    '      path: fixtures/token.txt',
+    '',
+  ].join('\n'));
+  fs.writeFileSync(path.join(root, 'trivy', 'trivy-fs.json'), JSON.stringify({
+    Results: [
+      {
+        Target: 'services/api/package-lock.json',
+        Vulnerabilities: [
+          { VulnerabilityID: 'CVE-LOCAL-PATH', PkgName: 'api-lib', Severity: 'CRITICAL', PrimaryURL: 'https://example.test/CVE-LOCAL-PATH' },
+          { VulnerabilityID: 'CVE-ROOT-PATH', PkgName: 'root-lib', Severity: 'HIGH', PrimaryURL: 'https://example.test/CVE-ROOT-PATH' },
+        ],
+      },
+      {
+        Target: 'services/web/package-lock.json',
+        Vulnerabilities: [
+          { VulnerabilityID: 'CVE-LOCAL-PATH', PkgName: 'web-lib', Severity: 'HIGH', PrimaryURL: 'https://example.test/CVE-LOCAL-PATH' },
+          { VulnerabilityID: 'CVE-ROOT-PATH', PkgName: 'root-lib', Severity: 'HIGH', PrimaryURL: 'https://example.test/CVE-ROOT-PATH' },
+        ],
+      },
+    ],
+  }));
+  fs.writeFileSync(path.join(root, 'trufflehog', 'findings.ndjson'), [
+    JSON.stringify({ id: 'local-secret', detector: 'Github', status: 'verified', file: 'services/api/fixtures/token.txt', line: 1, commit: 'abcdef1234567890', url: 'https://example.test/blob/abcdef/services/api/fixtures/token.txt#L1' }),
+    JSON.stringify({ id: 'local-secret', detector: 'Github', status: 'verified', file: 'services/web/fixtures/token.txt', line: 1, commit: 'abcdef1234567890', url: 'https://example.test/blob/abcdef/services/web/fixtures/token.txt#L1' }),
+    JSON.stringify({ id: 'root-secret', detector: 'Github', status: 'verified', file: 'services/web/root.env', line: 1, commit: 'abcdef1234567890', url: 'https://example.test/blob/abcdef/services/web/root.env#L1' }),
+  ].join('\n') + '\n');
+
+  const outputs = {};
+  const failures = [];
+  await buildSourceSecurityReport({
+    env: {
+      ROOT: root,
+      GITHUB_WORKSPACE: workspace,
+      DRY_RUN: 'false',
+      BLOCKING_SEVERITY: 'high',
+      SCOPE: 'changes',
+      BASE: 'base-sha',
+      SECRET_SCAN_RESULT: 'success',
+      SCA_SCAN_RESULT: 'success',
+      P2P_SECURITY_IGNORE_HELPER: helperPath,
+      GITHUB_SERVER_URL: 'https://github.example',
+      GITHUB_REPOSITORY: 'org/repo',
+      GITHUB_RUN_ID: '42',
+    },
+    core: {
+      setOutput: (key, value) => { outputs[key] = value; },
+      setFailed: (message) => { failures.push(message); },
+      info: () => {},
+      warning: () => {},
+      summary: {
+        addRaw() {
+          return this;
+        },
+        write() {
+          return Promise.resolve();
+        },
+      },
+    },
+  });
+  return {
+    outputs,
+    failures,
+    normalized: JSON.parse(fs.readFileSync(outputs['json-file'], 'utf8')),
+  };
+}
+
+async function runReportWithNestedInvalidIgnoreFile(ignoreFile, dryRun = false) {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'source-nested-invalid-ignore-'));
+  const root = path.join(tmp, 'source-security');
+  const workspace = path.join(tmp, 'repo');
+  fs.mkdirSync(path.join(root, 'trivy'), { recursive: true });
+  fs.mkdirSync(path.join(root, 'trufflehog'), { recursive: true });
+  fs.mkdirSync(path.join(workspace, 'services', 'api'), { recursive: true });
+  fs.writeFileSync(path.join(workspace, 'services', 'api', '.p2p-security-ignore.yaml'), ignoreFile);
+  fs.writeFileSync(path.join(root, 'trivy', 'trivy-fs.json'), JSON.stringify({ Results: [] }));
+  fs.writeFileSync(path.join(root, 'trufflehog', 'findings.ndjson'), '');
+
+  await buildSourceSecurityReport({
+    env: {
+      ROOT: root,
+      GITHUB_WORKSPACE: workspace,
+      DRY_RUN: dryRun ? 'true' : 'false',
+      BLOCKING_SEVERITY: 'high',
+      SCOPE: 'changes',
+      BASE: 'base-sha',
+      SECRET_SCAN_RESULT: 'success',
+      SCA_SCAN_RESULT: 'success',
+      P2P_SECURITY_IGNORE_HELPER: helperPath,
+      GITHUB_SERVER_URL: 'https://github.example',
+      GITHUB_REPOSITORY: 'org/repo',
+      GITHUB_RUN_ID: '42',
+    },
+    core: {
+      setOutput: () => {},
+      setFailed: () => {},
+      info: () => {},
+      warning: () => {},
+      summary: {
+        addRaw() {
+          return this;
+        },
+        write() {
+          return Promise.resolve();
+        },
+      },
+    },
+  });
+}
+
 async function runReportWithCorruptTruffleHogOutput() {
   const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'source-corrupt-secret-'));
   const root = path.join(tmp, 'source-security');
@@ -878,6 +1019,67 @@ async function runReportWithMissingTruffleHogOutput() {
     'secret-path-mismatch',
   ]);
 
+  const directoryScoped = await runDirectoryScopedIgnoreReport();
+  assert.deepStrictEqual(directoryScoped.failures, []);
+  assert.strictEqual(directoryScoped.outputs['vulnerability-total'], 2);
+  assert.strictEqual(directoryScoped.outputs['vulnerability-blocking'], 2);
+  assert.strictEqual(directoryScoped.outputs['secret-total'], 1);
+  assert.strictEqual(directoryScoped.outputs['secret-blocking'], 1);
+  assert.deepStrictEqual(directoryScoped.normalized.ignored.vulnerabilities.map(v => ({
+    id: v.id,
+    source: v.source,
+    reason: v.ignore.reason,
+  })).sort((a, b) => a.source.localeCompare(b.source) || a.id.localeCompare(b.id)), [
+    {
+      id: 'CVE-LOCAL-PATH',
+      source: 'services/api/package-lock.json',
+      reason: 'API-local dependency risk.',
+    },
+    {
+      id: 'CVE-ROOT-PATH',
+      source: 'services/web/package-lock.json',
+      reason: 'Root path-scoped risk.',
+    },
+  ]);
+  assert.deepStrictEqual(directoryScoped.normalized.vulnerabilities.map(v => ({
+    id: v.id,
+    source: v.source,
+  })).sort((a, b) => a.source.localeCompare(b.source) || a.id.localeCompare(b.id)), [
+    {
+      id: 'CVE-ROOT-PATH',
+      source: 'services/api/package-lock.json',
+    },
+    {
+      id: 'CVE-LOCAL-PATH',
+      source: 'services/web/package-lock.json',
+    },
+  ]);
+  assert.deepStrictEqual(directoryScoped.normalized.ignored.secrets.map(s => ({
+    id: s.id,
+    file: s.file,
+    reason: s.ignore.reason,
+  })).sort((a, b) => a.file.localeCompare(b.file)), [
+    {
+      id: 'local-secret',
+      file: 'services/api/fixtures/token.txt',
+      reason: 'API-local source secret.',
+    },
+    {
+      id: 'root-secret',
+      file: 'services/web/root.env',
+      reason: 'Root source secret.',
+    },
+  ]);
+  assert.deepStrictEqual(directoryScoped.normalized.secrets.map(s => ({
+    id: s.id,
+    file: s.file,
+  })), [
+    {
+      id: 'local-secret',
+      file: 'services/web/fixtures/token.txt',
+    },
+  ]);
+
   const offModeVerifiedSecret = await runOffModeVerifiedSecretReport();
   assert.deepStrictEqual(offModeVerifiedSecret.failures, []);
   assert.strictEqual(offModeVerifiedSecret.outputs['security-risk'], 'critical');
@@ -913,6 +1115,23 @@ async function runReportWithMissingTruffleHogOutput() {
       name,
     );
   }
+  for (const [name, ignoreFile, expected] of [
+    ['nested malformed YAML', 'version: 1\nsource:\n  vulnerabilities:\n    - id: CVE-1\n      reason: [unterminated\n', 'Invalid .p2p-security-ignore.yaml'],
+    ['nested schema invalid', 'version: 1\nsource:\n  secrets:\n    - id: nested-secret\n', 'source.secrets[0].reason must be a non-empty string'],
+    ['nested vulnerability path escape', 'version: 1\nsource:\n  vulnerabilities:\n    - id: CVE-1\n      reason: escape\n      paths:\n        - ../package-lock.json\n', 'source.vulnerabilities[0].paths[0] must not resolve outside the ignore file directory'],
+    ['nested secret path escape', 'version: 1\nsource:\n  secrets:\n    - id: nested-secret\n      reason: escape\n      path: ../secrets.env\n', 'source.secrets[0].path must not resolve outside the ignore file directory'],
+  ]) {
+    await assert.rejects(
+      () => runReportWithNestedInvalidIgnoreFile(ignoreFile),
+      error => error.message.includes(expected),
+      name,
+    );
+  }
+  await assert.rejects(
+    () => runReportWithNestedInvalidIgnoreFile('version: 1\nsource:\n  vulnerabilities:\n    - id: CVE-DRY\n', true),
+    error => error.message.includes('source.vulnerabilities[0].reason must be a non-empty string'),
+    'dry-run validates discovered nested ignore files',
+  );
   await assert.rejects(
     () => runReportWithCorruptTruffleHogOutput(),
     error => error.message.includes('Failed to process TruffleHog source report'),

--- a/.github/workflows/p2p-workflow-image-scan.yaml
+++ b/.github/workflows/p2p-workflow-image-scan.yaml
@@ -243,6 +243,7 @@ jobs:
           VERSION: ${{ inputs.version }}
           ARTIFACT_DIR: ${{ steps.manifest.outputs.artifact-dir }}
           SCAN_TARGET_COUNT: ${{ steps.pull-images.outputs.scan-target-count }}
+          WORKING_DIR: ${{ inputs.working-directory }}
           P2P_SECURITY_IGNORE_HELPER: ${{ runner.temp }}/p2p-workflow-src/.github/scripts/p2p-security-ignore.js
           P2P_IMAGE_SECURITY_REPORT: ${{ runner.temp }}/p2p-workflow-src/.github/scripts/image-security-report.js
         with:

--- a/docs/adrs/0001-managed-security-scanning.md
+++ b/docs/adrs/0001-managed-security-scanning.md
@@ -18,13 +18,13 @@ The first two cases are developer feedback. The last case is monitoring and audi
 
 P2P provides managed security scanning through reusable GitHub Actions workflows.
 
-Fast-feedback now runs source security scanning and image scanning automatically on pull requests and pushes. Source security scanning checks changed git history for committed secrets, and checks the current source tree for dependency vulnerabilities. Trivy source scanning is intentionally not limited to the configured `working-directory`, because dependency manifests and related modules can live outside the P2P make target directory. Image scanning checks the built P2P container images for known vulnerabilities and embedded secrets.
+Fast-feedback now runs source security scanning and image scanning automatically on pull requests and pushes. Source security scanning is repository-wide, not folder-scoped: TruffleHog checks the changed git history for committed secrets, and Trivy source dependency vulnerability scanning/SCA checks the current source tree. Neither source scanner is limited to the configured `working-directory`; that input affects make target execution, image build context, and image ignore-file selection, not source scanner scope. Image scanning checks the built P2P container images for known vulnerabilities and embedded secrets.
 
 The workflows are visibility-first by default: findings are reported in workflow run summaries, artifacts, and PR comments where permissions allow, but they do not block unless the caller sets `security-scan-blocking-severity` to `low`, `medium`, `high`, or `critical`. Promotion waits for the scan jobs to complete, so scanner execution failures stop promotion. Security findings stop promotion only when they meet the configured blocking threshold.
 
 P2P also provides a scheduled umbrella workflow, `p2p-workflow-security-scan`, for repositories that want periodic monitoring. A repository enables it with a small cron wrapper. Each scheduled run scans:
 
-- the repository source history for secrets, and the current branch source tree for dependency vulnerabilities and license signals;
+- the repository source history for secrets, and the current branch source tree for dependency vulnerabilities/SCA and license signals;
 - the latest fast-feedback images;
 - the latest extended-test images;
 - the latest production images.
@@ -60,7 +60,9 @@ jobs:
 
 Teams read results in the GitHub Actions workflow run summary and artifacts. The source scan writes source vulnerability and secret results to the workflow run summary on every non-dry-run scan. On pull requests, source scan comments are posted when the workflow has `pull-requests: write`; image scan comments are also posted when that permission is granted through the caller chain. If the permission is omitted, image scanning still runs and uploads artifacts, but PR comment posting is non-fatal.
 
-Application repositories may add a P2P-owned `.p2p-security-ignore.yaml` file at the repository root to record accepted source and image security findings. Valid, unexpired ignore entries remove matching findings from active report tables, active totals, blocking counts, and policy failures while keeping ignored records in normalized JSON artifacts for dashboard ingestion. Malformed ignore files, unsupported schema versions, invalid shapes, or invalid expiry dates fail report generation instead of silently weakening policy.
+Scheduled source security scanning is also repository-wide, not folder-scoped: TruffleHog scans reachable git history for secrets, and Trivy source dependency vulnerability scanning/SCA scans the current branch source tree. As in fast-feedback, `working-directory` does not limit source scanner scope.
+
+Application repositories may add P2P-owned `.p2p-security-ignore.yaml` files to record accepted security findings. Source report generation discovers every `.p2p-security-ignore.yaml` in the repository; each file's source entries apply only to findings under that file's directory, so the repository-root file applies to the whole repository. Image report generation reads the repository-root ignore file plus the ignore file in the selected `working-directory`. Valid, unexpired ignore entries remove matching findings from active report tables, active totals, blocking counts, and policy failures while keeping ignored records in normalized JSON artifacts for dashboard ingestion. Malformed ignore files, unsupported schema versions, invalid shapes, or invalid expiry dates fail report generation instead of silently weakening policy.
 
 ## Scanner choices
 

--- a/docs/adrs/0001-managed-security-scanning.md
+++ b/docs/adrs/0001-managed-security-scanning.md
@@ -24,7 +24,7 @@ The workflows are visibility-first by default: findings are reported in workflow
 
 P2P also provides a scheduled umbrella workflow, `p2p-workflow-security-scan`, for repositories that want periodic monitoring. A repository enables it with a small cron wrapper. Each scheduled run scans:
 
-- the repository source history for secrets, and the current branch source tree for dependency vulnerabilities/SCA and license signals;
+- the repository source history for secrets, and the current branch source tree for dependency vulnerabilities/SCA;
 - the latest fast-feedback images;
 - the latest extended-test images;
 - the latest production images.

--- a/docs/explanation/secrets-scanning.md
+++ b/docs/explanation/secrets-scanning.md
@@ -1,6 +1,6 @@
 # Secrets scanning
 
-P2P provides platform-managed secrets scanning so application teams do not have to choose, configure, and maintain their own scanner. Secrets are now part of the internal [`p2p-workflow-source-security-scan`](../reference/p2p-workflow-source-security-scan.md) reusable workflow, alongside source dependency vulnerabilities and restricted or forbidden license signals. Fast-feedback calls it on every PR and push, and scheduled wrappers should call it through the [scheduled security umbrella](../reference/p2p-workflow-security-scan.md).
+P2P provides platform-managed secrets scanning so application teams do not have to choose, configure, and maintain their own scanner. Secrets are now part of the internal [`p2p-workflow-source-security-scan`](../reference/p2p-workflow-source-security-scan.md) reusable workflow, alongside source dependency vulnerabilities. Fast-feedback calls it on every PR and push, and scheduled wrappers should call it through the [scheduled security umbrella](../reference/p2p-workflow-security-scan.md).
 
 ## What gets scanned and when
 
@@ -9,7 +9,7 @@ P2P provides platform-managed secrets scanning so application teams do not have 
 | PR / push | `changes` - the delta (only commits introduced by the PR or push) | `p2p-workflow-fastfeedback` | No (opt in with `security-scan-blocking-severity: low`, `medium`, `high`, or `critical`) |
 | Cron | `full-history` - every reachable commit | `p2p-workflow-security-scan` wrapper | No |
 
-The two modes serve different purposes: the PR/push mode is a **gate candidate** that surfaces new secrets as they are introduced and can be promoted to a hard gate by setting `security-scan-blocking-severity` to a non-`off` threshold; the scheduled mode is a **monitoring signal** that surfaces legacy findings and re-checks dormant repositories. When blocking is enabled, verified secrets are treated as `critical`. The same source security report also shows source vulnerabilities and restricted or forbidden license findings.
+The two modes serve different purposes: the PR/push mode is a **gate candidate** that surfaces new secrets as they are introduced and can be promoted to a hard gate by setting `security-scan-blocking-severity` to a non-`off` threshold; the scheduled mode is a **monitoring signal** that surfaces legacy findings and re-checks dormant repositories. When blocking is enabled, verified secrets are treated as `critical`. The same source security report also shows source vulnerabilities.
 
 ## See also
 

--- a/docs/how-to/enable-scheduled-security-scanning.md
+++ b/docs/how-to/enable-scheduled-security-scanning.md
@@ -38,12 +38,12 @@ jobs:
 
 Each scheduled run starts these scans:
 
-- source security scan over the repository's reachable git history for secrets and current source tree for dependency vulnerabilities and license signals;
+- source security scan over the repository's reachable git history for secrets and current source tree for dependency vulnerabilities;
 - latest fast-feedback images for each environment in `vars.FAST_FEEDBACK`;
 - latest extended-test images for each environment in `vars.EXTENDED_TEST`;
 - latest production images for each environment in `vars.PROD`.
 
-The source scan uses TruffleHog for committed secrets and Trivy for source dependency vulnerabilities plus restricted or forbidden license signals. In scheduled scans, `full-history` applies to TruffleHog git scanning; Trivy scans the current branch's checked-out source tree. The image scans use Trivy for image vulnerabilities and TruffleHog for embedded image secrets.
+The source scan uses TruffleHog for committed secrets and Trivy for source dependency vulnerabilities. In scheduled scans, `full-history` applies to TruffleHog git scanning; Trivy scans the current branch's checked-out source tree. The image scans use Trivy for image vulnerabilities and TruffleHog for embedded image secrets.
 
 Scheduled scans are report-only by default. The wrapper passes `security-scan-blocking-severity: 'off'`, so findings can fail the child policy jobs without failing the umbrella workflow. Scanner execution errors, authentication errors, and invalid configuration still fail the workflow.
 

--- a/docs/how-to/ignore-security-findings.md
+++ b/docs/how-to/ignore-security-findings.md
@@ -39,6 +39,6 @@ Rules for v1:
 - `expires` is optional for vulnerabilities and secrets. If present, it must use `YYYY-MM-DD`. If absent, the ignore has no expiry. If present and in the past, the ignore no longer applies.
 - Optional narrowing fields use exact matching in v1. Globs and regular expressions are not supported.
 - `app-name` scopes sticky PR comments only. It does not select source scanner scope or security ignore files.
-- License finding ignores and stage-specific ignores are out of scope for v1.
+- Stage-specific ignores are out of scope for v1.
 
 For source secrets, copy the exact `id` from `source-security-findings.json`. For image secrets, copy the `id` from the image PR comment, `image-security-findings.json`, or the dashboard evidence. Do not write raw secret values to `.p2p-security-ignore.yaml`; P2P secret finding IDs are redacted specifically so accepted secret findings can be tracked without disclosing the secret.

--- a/docs/how-to/ignore-security-findings.md
+++ b/docs/how-to/ignore-security-findings.md
@@ -1,6 +1,6 @@
 # How to Ignore Security Findings
 
-Use the repository-root `.p2p-security-ignore.yaml` file only after confirming the finding is accepted risk. The file is a P2P product contract, not a scanner-native Trivy or TruffleHog ignore file.
+Use `.p2p-security-ignore.yaml` only after confirming the finding is accepted risk. The file is a P2P product contract, not a scanner-native Trivy or TruffleHog ignore file.
 
 Ignored findings are omitted from PR comments and workflow summaries. They are excluded from active totals, blocking counts, and policy failures. They remain available in `source-security-findings.json` and `image-security-findings.json` under `ignored.vulnerabilities` and `ignored.secrets` so the dashboard can display accepted risk separately with the recorded reason.
 
@@ -29,13 +29,16 @@ source:
 
 Rules for v1:
 
-- The ignore file path is `.p2p-security-ignore.yaml` at the repository root.
+- Source scans discover every `.p2p-security-ignore.yaml` in the repository. Each file's `source` entries apply only to source findings under the directory containing that file. The repository-root file applies to the whole repository.
+- Image scans read only the repository-root `.p2p-security-ignore.yaml` plus the `.p2p-security-ignore.yaml` in the selected `working-directory`. Image scans do not discover ignore files from other directories.
 - The schema version is `version: 1`.
 - Image entries require `name`; it matches the standard P2P image name, not a registry reference, tag, stage, or GitHub environment.
 - Vulnerability ignores require `id` and `reason`. `package` is optional for source and image vulnerabilities. `paths` is optional for source vulnerabilities and narrows matching to Trivy filesystem result target paths.
 - Secret ignores require `id` and `reason`. `path` is optional for source and image secrets.
+- Source vulnerability `paths` and source secret `path` values in the repository-root ignore file are repository-relative. The same fields in nested ignore files are relative to the directory containing that ignore file. Source path filters that resolve outside that directory, including `..` escapes, fail validation.
 - `expires` is optional for vulnerabilities and secrets. If present, it must use `YYYY-MM-DD`. If absent, the ignore has no expiry. If present and in the past, the ignore no longer applies.
 - Optional narrowing fields use exact matching in v1. Globs and regular expressions are not supported.
-- License finding ignores, stage-specific ignores, multiple ignore files, and `working-directory`-relative ignore files are out of scope for v1.
+- `app-name` scopes sticky PR comments only. It does not select source scanner scope or security ignore files.
+- License finding ignores and stage-specific ignores are out of scope for v1.
 
 For source secrets, copy the exact `id` from `source-security-findings.json`. For image secrets, copy the `id` from the image PR comment, `image-security-findings.json`, or the dashboard evidence. Do not write raw secret values to `.p2p-security-ignore.yaml`; P2P secret finding IDs are redacted specifically so accepted secret findings can be tracked without disclosing the secret.

--- a/docs/how-to/triage-security-findings.md
+++ b/docs/how-to/triage-security-findings.md
@@ -9,18 +9,15 @@ On pull requests, the scanners upsert sticky comments in the PR conversation ins
 | Source | Sticky comment header | Artifact |
 |---|---|---|
 | Source vulnerabilities | `security-source-scan-findings-<app-name>` | `security-source-scan-findings` |
-| Source restricted/forbidden licenses | `security-source-scan-findings-<app-name>` | `security-source-scan-findings` |
 | Git tree secrets | `security-source-scan-findings-<app-name>` | `security-source-scan-findings` |
 | Image vulnerabilities | `security-image-scan-findings-<app-name>-<stage>-<github_env>` | `security-image-scan-reports-<stage>-<github_env>` |
 | Image secrets | `security-image-scan-findings-<app-name>-<stage>-<github_env>` (same comment as image vulnerabilities for that app/stage/environment) | `security-image-scan-reports-<stage>-<github_env>` |
-
-Restricted and forbidden license findings are shown for triage only. The source scan reports only HIGH and CRITICAL license classifications. Trivy's license classification is not a legal decision and is not a P2P-wide organization policy; confirm the finding against your organization's open-source policy before taking enforcement action.
 
 PR comments are optional for backward compatibility with orchestrator workflows that existed before security scans posted comments. If the caller does not grant `pull-requests: write`, the workflows still write summaries and upload artifacts, but the sticky PR comment steps are non-fatal and cannot update the PR.
 
 P2P workflow templates pass `app-name` to security scans so each app updates its own source and image security comments.
 
-The source-security comment renders source vulnerabilities, restricted or forbidden licenses, and git-tree secrets under one header. Vulnerability rows include package, installed version, fixed version, CVE, and source where available. License rows identify the package and detected license. Git-tree secret rows show `Detector`, `Status`, `File`, `Line`, and `Commit`.
+The source-security comment renders source vulnerabilities and git-tree secrets under one header. Vulnerability rows include package, installed version, fixed version, CVE, and source where available. Git-tree secret rows show `Detector`, `Status`, `File`, `Line`, and `Commit`.
 
 The security-image-scan comment renders up to two tables under one header:
 
@@ -39,9 +36,9 @@ If the PR comment is truncated or you need raw data:
    - `security-source-scan-findings` for source-security output (contains redacted TruffleHog findings, raw Trivy filesystem output, and `source-security-findings.json`)
    - `security-image-scan-reports-<stage>-<github_env>` for security-image-scan output (contains `manifest.json`, `image-security-findings.json`, `trivy/`, and `trufflehog-image/`)
 
-The image artifact's root `manifest.json` is the supported index. It records the stage and points to artifact-relative raw Trivy JSON reports under `trivy/` and redacted TruffleHog JSON-lines reports under `trufflehog-image/`, both keyed by scanned image x platform. A configured OCI reference can be absent from `manifest.json` when the workflow skipped it as non-scannable, such as a Helm chart artifact or confirmed empty container image; check the security-image-scan job logs for skip warnings. A TruffleHog JSONL file can be empty when no image secrets were found. Dashboard evidence does not expose secret values; use the P2P redacted secret ID, detector, status, layer, and path metadata for triage. The `security-source-scan-findings` artifact contains raw Trivy filesystem output, redacted TruffleHog source findings, and `source-security-findings.json` for source vulnerabilities, source license findings, and git-tree secrets.
+The image artifact's root `manifest.json` is the supported index. It records the stage and points to artifact-relative raw Trivy JSON reports under `trivy/` and redacted TruffleHog JSON-lines reports under `trufflehog-image/`, both keyed by scanned image x platform. A configured OCI reference can be absent from `manifest.json` when the workflow skipped it as non-scannable, such as a Helm chart artifact or confirmed empty container image; check the security-image-scan job logs for skip warnings. A TruffleHog JSONL file can be empty when no image secrets were found. Dashboard evidence does not expose secret values; use the P2P redacted secret ID, detector, status, layer, and path metadata for triage. The `security-source-scan-findings` artifact contains raw Trivy filesystem output, redacted TruffleHog source findings, and `source-security-findings.json` for source vulnerabilities and git-tree secrets.
 
-`source-security-findings.json` uses top-level `vulnerabilities`, `licenses`, and `secrets` collections. `image-security-findings.json` uses top-level `vulnerabilities` and `secrets` collections. When an ignore file is present, both files also include `ignored.vulnerabilities` and `ignored.secrets`; ignored records include the matched reason and expiry metadata when present. This lets dashboard ingestion display ignored findings alongside active findings without treating them as active remediation or blocking policy counts.
+`source-security-findings.json` uses top-level `vulnerabilities` and `secrets` collections. `image-security-findings.json` uses top-level `vulnerabilities` and `secrets` collections. When an ignore file is present, both files also include `ignored.vulnerabilities` and `ignored.secrets`; ignored records include the matched reason and expiry metadata when present. This lets dashboard ingestion display ignored findings alongside active findings without treating them as active remediation or blocking policy counts.
 
 ## 3. Remediate first when the scan is correct
 
@@ -49,7 +46,6 @@ Preferred fixes:
 
 - For image findings, update the vulnerable package or base image so the next build produces a clean image.
 - For source vulnerability findings, update the affected dependency or lockfile entry so the vulnerable version is no longer present.
-- For restricted or forbidden license findings, confirm the package and license against your organization's open-source policy before changing dependencies or taking enforcement action.
 - For git-tree secret findings, remove the committed secret, rotate the credential, and replace it with a proper secret store or GitHub secret.
 - For embedded secrets, rotate the credential first, identify which Dockerfile step introduced it (the `Layer` column points to the layer digest — match it against `docker history <image>`), scrub or rebuild from a fresh base, and re-push the image. A secret that appears in both the *Source security scan* (git-tree secrets) and *Image scan* (Secrets in image) comments means the source is in the tracked tree — fix the git source first and the image side will resolve on the next build.
 

--- a/docs/reference/p2p-workflow-fastfeedback.md
+++ b/docs/reference/p2p-workflow-fastfeedback.md
@@ -85,6 +85,8 @@ security-image-scan           (needs: build)
 security-source-scan  (independent of build; runs in parallel)
                       Calls p2p-workflow-source-security-scan with secret-scan-scope: changes.
                       Checks out the same checkout-version ref as build/test jobs.
+                      Scans source repository-wide; working-directory does not narrow
+                      TruffleHog source secret scanning or Trivy source SCA.
                       Reports source vulnerabilities, restricted/forbidden licenses,
                       and git-tree secrets. Blocks only on vulnerabilities at or above
                       security-scan-blocking-severity or verified secrets when the

--- a/docs/reference/p2p-workflow-fastfeedback.md
+++ b/docs/reference/p2p-workflow-fastfeedback.md
@@ -87,8 +87,8 @@ security-source-scan  (independent of build; runs in parallel)
                       Checks out the same checkout-version ref as build/test jobs.
                       Scans source repository-wide; working-directory does not narrow
                       TruffleHog source secret scanning or Trivy source SCA.
-                      Reports source vulnerabilities, restricted/forbidden licenses,
-                      and git-tree secrets. Blocks only on vulnerabilities at or above
+                      Reports source vulnerabilities and git-tree secrets.
+                      Blocks only on vulnerabilities at or above
                       security-scan-blocking-severity or verified secrets when the
                       threshold is not off.
 

--- a/docs/reference/p2p-workflow-image-scan.md
+++ b/docs/reference/p2p-workflow-image-scan.md
@@ -14,11 +14,11 @@ Internal workflow called by [`p2p-workflow-fastfeedback`](p2p-workflow-fastfeedb
 | `version` | string | Yes | — | Image tag to scan. Used with each standard P2P image name to build the stage Artifact Registry reference. |
 | `github_env` | string | No | `''` | GitHub Environment used for environment-scoped variables and GCP auth. Required in practice — image pulls go through Workload Identity Federation bound to this environment. |
 | `tenant-name` | string | No | `''` | Tenant identifier. Falls back to `vars.TENANT_NAME` when empty. |
-| `app-name` | string | No | `''` | Application name used to scope sticky PR comments in multi-app repositories. Primary P2P workflow templates pass this through. When omitted by direct callers, comment scope falls back to `tenant-name`, then `vars.TENANT_NAME`. |
+| `app-name` | string | No | `''` | Application name used to scope sticky PR comments in multi-app repositories. It does not select security ignore files. Primary P2P workflow templates pass this through. When omitted by direct callers, comment scope falls back to `tenant-name`, then `vars.TENANT_NAME`. |
 | `region` | string | No | `europe-west2` | GCP region for the Artifact Registry. Overridden by `vars.REGION` when set on the environment. |
 | `working-directory` | string | No | `.` | Directory from which `make p2p-images` is executed when `image-names` is empty. |
 | `image-names` | string | No | `''` | Newline-, comma-, or whitespace-separated list of standard P2P image names to scan. When set, this list is used instead of `make p2p-images`. |
-| `dry-run` | boolean | No | `false` | When `true`, still checks out the repo and resolves image names from `image-names` or `make p2p-images`, then skips GCP auth, registry login, image pulls, scanner installs, scans, sticky PR comment, artifact upload, and policy step. The `Build report` step still runs and produces a "Scan skipped" summary. Dry-run still parses `.p2p-security-ignore.yaml`, so a malformed ignore file can fail report generation. |
+| `dry-run` | boolean | No | `false` | When `true`, still checks out the repo and resolves image names from `image-names` or `make p2p-images`, then skips GCP auth, registry login, image pulls, scanner installs, scans, sticky PR comment, artifact upload, and policy step. The `Build report` step still runs and produces a "Scan skipped" summary. Dry-run still parses the repository-root and selected `working-directory` `.p2p-security-ignore.yaml` files, so a malformed selected ignore file can fail report generation. |
 | `checkout-version` | string | No | `''` | Git ref to check out before resolving image names. Ignored when `dry-run` is `true`; the workflow checks out the default ref. |
 | `blocking-severity` | string | No | `off` | Minimum finding severity that blocks the workflow: `off`, `low`, `medium`, `high`, or `critical`. When blocking is enabled, verified image secrets are treated as `critical`. The `security-image-policy` job fails on active vulnerability or secret findings, but the workflow continues when findings are below the blocking threshold. |
 | `ignore-unfixed` | boolean | No | `true` | When `true`, passes `--ignore-unfixed` to Trivy — only vulnerabilities with a fixed version are reported. |
@@ -50,7 +50,7 @@ Results are also surfaced via:
 - A sticky PR comment with `header: security-image-scan-findings-<app-name>-<stage>-<github_env>` on `pull_request` events when `dry-run: false` and the caller grants `pull-requests: write`. When `github_env` is empty, the header uses `local`.
 - The `security-image-scan-reports-<stage>-<github_env>` artifact, retained for 30 days. When `github_env` is empty, the artifact name uses `local`. Contains root `manifest.json`, `image-security-findings.json`, `trivy/` (one Trivy JSON per scanned image x platform), and `trufflehog-image/` (one redacted TruffleHog JSON-lines file per scanned image x platform).
 
-If the repository root contains `.p2p-security-ignore.yaml`, image vulnerability and image secret findings that match a valid, unexpired ignore entry are omitted from active finding tables in the workflow summary and sticky PR comment. Ignored findings stay visible in `image-security-findings.json` with their ignore reason and expiry metadata when present. They are excluded from active totals, active blocking counts, and image policy failures.
+Image report generation reads the repository-root `.p2p-security-ignore.yaml` and, when `working-directory` is non-root, the `.p2p-security-ignore.yaml` file in that selected directory. It does not discover ignore files from other directories. Image vulnerability and image secret findings that match a valid, unexpired ignore entry in those files are omitted from active finding tables in the workflow summary and sticky PR comment. Ignored findings stay visible in `image-security-findings.json` with their ignore reason and expiry metadata when present. They are excluded from active totals, active blocking counts, and image policy failures.
 
 `image-security-findings.json` uses top-level `vulnerabilities` and `secrets` collections. When an ignore file is present, it also includes `ignored.vulnerabilities` and `ignored.secrets`.
 
@@ -80,7 +80,7 @@ If neither `image-names` nor `p2p-images` produces candidate names, or if all ca
 
 ## Security ignore file
 
-The security-image-scan workflow reads one P2P-owned ignore file from the repository root: `.p2p-security-ignore.yaml`. If the file is absent, scans behave normally. If it is present but malformed, uses an unsupported schema version, omits required fields, has invalid shapes, or contains invalid expiry dates, the scan/report job fails.
+The security-image-scan workflow reads P2P-owned ignore files from the repository root and the selected `working-directory`: `.p2p-security-ignore.yaml`. If both files are absent, scans behave normally. If either selected file is malformed, uses an unsupported schema version, omits required fields, has invalid shapes, or contains invalid expiry dates, the scan/report job fails. Image entries still require `images[].name`.
 
 See [How to ignore security findings](../how-to/ignore-security-findings.md) for the v1 schema, matching rules, and secret ID guidance.
 

--- a/docs/reference/p2p-workflow-security-scan.md
+++ b/docs/reference/p2p-workflow-security-scan.md
@@ -59,7 +59,7 @@ jobs:
 None. Results are surfaced via:
 
 - Each child job's workflow summary (`$GITHUB_STEP_SUMMARY`).
-- On non-dry-run source scans where report generation completes, the `security-source-scan-findings` artifact from the security-source-scan job. It contains redacted TruffleHog output, raw Trivy filesystem output when available, and normalized merged JSON. Scheduled source scanning uses TruffleHog for reachable git history and Trivy for the current branch's checked-out source tree. Scanner warnings or incomplete scanner output still fail the `security-source-scan-status-policy` job.
+- On non-dry-run source scans where report generation completes, the `security-source-scan-findings` artifact from the security-source-scan job. It contains redacted TruffleHog output, raw Trivy filesystem output when available, and normalized merged JSON. Scheduled source scanning is repository-wide: TruffleHog scans reachable git history and Trivy source dependency vulnerability scanning/SCA scans the current branch's checked-out source tree. Scanner warnings or incomplete scanner output still fail the `security-source-scan-status-policy` job.
 - On successful non-dry-run image scans where a latest image tag is found and at least one scannable container image is available, the `security-image-scan-reports-<stage>-<github_env>` artifact from each security-image-scan job. Each artifact contains root `manifest.json`, `trivy/` vulnerability JSON reports, and `trufflehog-image/` secret JSON-lines reports for scanned image/platform pairs. `manifest.json` records the P2P stage (`fast-feedback`, `extended-test`, or `prod`) and is the supported artifact index.
 
 ## Job Graph
@@ -73,7 +73,7 @@ security-resolve-anchor-image
 security-source-scan                                   (independent; runs in parallel)
 ```
 
-Each matrix entry calls an internal stage workflow that first discovers the latest version for that stage/environment and then scans that exact version. The security-source-scan job runs in parallel with the per-stage matrices. For source scans, `secret-scan-scope: full-history` applies to TruffleHog git scanning; Trivy scans only the current checked-out branch tree. The `security-scan-blocking-severity` input is passed to every child scan. Its default `off` keeps scheduled scans report-only; setting it to `low`, `medium`, `high`, or `critical` makes findings at or above that severity fail the umbrella workflow, while below-threshold findings fail only the child policy job.
+Each matrix entry calls an internal stage workflow that first discovers the latest version for that stage/environment and then scans that exact version. The security-source-scan job runs in parallel with the per-stage matrices. For source scans, `secret-scan-scope: full-history` applies to repository-wide TruffleHog git scanning; Trivy scans the current checked-out branch tree and is not limited to `working-directory`. The `security-scan-blocking-severity` input is passed to every child scan. Its default `off` keeps scheduled scans report-only; setting it to `low`, `medium`, `high`, or `critical` makes findings at or above that severity fail the umbrella workflow, while below-threshold findings fail only the child policy job.
 
 ## Version discovery
 

--- a/docs/reference/p2p-workflow-source-security-scan.md
+++ b/docs/reference/p2p-workflow-source-security-scan.md
@@ -1,6 +1,6 @@
 # p2p-workflow-source-security-scan
 
-> Scans repository source for committed secrets, dependency vulnerabilities, and restricted or forbidden licenses. Produces a workflow summary, optionally posts a sticky PR comment on `pull_request` events when permissions allow, and uploads a `security-source-scan-findings` artifact. The `security-source-policy` job fails on active vulnerability or secret findings; the configured blocking severity controls whether that policy failure fails the workflow.
+> Scans repository source for committed secrets and dependency vulnerabilities. Produces a workflow summary, optionally posts a sticky PR comment on `pull_request` events when permissions allow, and uploads a `security-source-scan-findings` artifact. The `security-source-policy` job fails on active vulnerability or secret findings; the configured blocking severity controls whether that policy failure fails the workflow.
 
 ## Usage
 
@@ -36,10 +36,9 @@ The workflow inherits permissions from the caller. Grant:
 | `json-file` | Path to `source-security-findings.json` on the runner, normally under `runner.temp`. |
 | `vulnerability-total` | Number of source vulnerability findings in the normalized report. |
 | `vulnerability-blocking` | Number of reported vulnerability findings at or above `blocking-severity`. |
-| `license-total` | Number of restricted or forbidden license findings in the normalized report. |
 | `secret-total` | Number of redacted TruffleHog findings in the normalized report. |
 | `secret-blocking` | Number of TruffleHog findings with `status: verified` when `blocking-severity` is not `off`. |
-| `security-risk` | Maximum active source vulnerability/secret risk after ignore rules: `critical`, `unclassified`, `high`, `medium`, `low`, `ok`, or `unknown`. License findings are not included. |
+| `security-risk` | Maximum active source vulnerability/secret risk after ignore rules: `critical`, `unclassified`, `high`, `medium`, `low`, `ok`, or `unknown`. |
 | `scan-status` | `ok` when scanner results were extracted successfully, otherwise `failed`. |
 
 Results are also surfaced via:
@@ -51,7 +50,7 @@ Results are also surfaced via:
 
 Source report generation discovers every `.p2p-security-ignore.yaml` in the repository. Source vulnerability and source secret findings that match a valid, unexpired ignore entry in an applicable ignore file are omitted from active finding tables in the workflow summary and sticky PR comment. Each ignore file's source entries apply only to findings under the directory containing that file; the repository-root ignore file applies to the whole repository. Ignored findings stay visible in `source-security-findings.json` with their ignore reason and expiry metadata when present. They are excluded from active totals, active blocking counts, and policy failures.
 
-`source-security-findings.json` uses top-level `vulnerabilities`, `licenses`, and `secrets` collections. When an ignore file is present, it also includes `ignored.vulnerabilities` and `ignored.secrets`.
+`source-security-findings.json` uses top-level `vulnerabilities` and `secrets` collections. When an ignore file is present, it also includes `ignored.vulnerabilities` and `ignored.secrets`.
 
 The source scan scope is scanner-specific and repository-wide, not folder-scoped. With `secret-scan-scope: changes`, TruffleHog scans the changed git commit range across the repository, while Trivy source dependency vulnerability scanning/SCA scans the current checked-out source tree. With `secret-scan-scope: full-history`, TruffleHog scans reachable git history across the repository, while Trivy scans the current branch's checked-out source tree. When called from fast-feedback, the source scan checks out the same `checkout-version` ref as build, test, and promotion jobs. `working-directory` does not limit either source scanner, so shared manifests and related modules outside the P2P make target directory are still covered.
 
@@ -68,10 +67,6 @@ The workflow is visibility-first by default. Scanner setup or execution errors a
 - `off`: findings do not fail the workflow, but the `security-source-policy` job fails when vulnerabilities or secrets are found;
 - `low`, `medium`, `high`, or `critical`: reported Trivy vulnerability findings below that threshold fail only the `security-source-policy` job, while findings at or above that threshold fail the workflow;
 - verified TruffleHog secrets are treated as `critical` findings and fail the workflow for any non-`off` threshold.
-
-Restricted and forbidden license findings are report-only for every threshold. The source scan reports only HIGH and CRITICAL license classifications.
-
-Trivy license classifications are triage signals, not a P2P-wide legal policy. Organization-specific allow/deny policy is out of scope for this version.
 
 ## See also
 

--- a/docs/reference/p2p-workflow-source-security-scan.md
+++ b/docs/reference/p2p-workflow-source-security-scan.md
@@ -11,11 +11,11 @@ Internal workflow called from [`p2p-workflow-fastfeedback`](p2p-workflow-fastfee
 | Name | Type | Required | Default | Description |
 |------|------|----------|---------|-------------|
 | `secret-scan-scope` | string | Yes | - | `changes` for PR/push scanning or `full-history` for scheduled monitoring. TruffleHog uses this to choose git history scope. Trivy scans the current checked-out source tree. |
-| `app-name` | string | No | `''` | Application name used to scope sticky PR comments in multi-app repositories. Primary P2P workflow templates pass this through. When omitted by direct callers, comment scope falls back to `tenant-name`, then `vars.TENANT_NAME`. |
+| `app-name` | string | No | `''` | Application name used to scope sticky PR comments in multi-app repositories. It does not select source scanner scope or security ignore files. Primary P2P workflow templates pass this through. When omitted by direct callers, comment scope falls back to `tenant-name`, then `vars.TENANT_NAME`. |
 | `tenant-name` | string | No | `''` | Tenant identifier used as the sticky comment scope fallback when `app-name` is omitted. |
 | `blocking-severity` | string | No | `off` | Minimum finding severity that blocks the workflow: `off`, `low`, `medium`, `high`, or `critical`. When blocking is enabled, verified secrets are treated as `critical`. The `security-source-policy` job fails on active vulnerability or secret findings, but the workflow continues when findings are below the blocking threshold. |
 | `ignore-unfixed` | boolean | No | `true` | Passed to Trivy vulnerability scanning. |
-| `dry-run` | boolean | No | `false` | When `true`, skips scanner installs, scans, sticky PR comments, artifact upload, and policy enforcement. The summary reports that the scan was skipped. Dry-run still parses `.p2p-security-ignore.yaml`, so a malformed ignore file can fail report generation. |
+| `dry-run` | boolean | No | `false` | When `true`, skips scanner installs, scans, sticky PR comments, artifact upload, and policy enforcement. The summary reports that the scan was skipped. Dry-run still parses discovered `.p2p-security-ignore.yaml` files, so a malformed ignore file can fail report generation. |
 | `checkout-version` | string | No | `''` | Git ref to check out before scanning. Ignored when `dry-run` is `true`; the workflow checks out the default ref. |
 | `timeout-minutes` | number | No | `30` | Job timeout for scanner jobs. |
 
@@ -49,17 +49,17 @@ Results are also surfaced via:
 - sticky PR comment with `header: security-source-scan-findings-<app-name>` on `pull_request` events;
 - `security-source-scan-findings` artifact containing redacted TruffleHog findings, raw Trivy filesystem output, and `source-security-findings.json`.
 
-If the repository root contains `.p2p-security-ignore.yaml`, source vulnerability and source secret findings that match a valid, unexpired ignore entry are omitted from active finding tables in the workflow summary and sticky PR comment. Ignored findings stay visible in `source-security-findings.json` with their ignore reason and expiry metadata when present. They are excluded from active totals, active blocking counts, and policy failures.
+Source report generation discovers every `.p2p-security-ignore.yaml` in the repository. Source vulnerability and source secret findings that match a valid, unexpired ignore entry in an applicable ignore file are omitted from active finding tables in the workflow summary and sticky PR comment. Each ignore file's source entries apply only to findings under the directory containing that file; the repository-root ignore file applies to the whole repository. Ignored findings stay visible in `source-security-findings.json` with their ignore reason and expiry metadata when present. They are excluded from active totals, active blocking counts, and policy failures.
 
 `source-security-findings.json` uses top-level `vulnerabilities`, `licenses`, and `secrets` collections. When an ignore file is present, it also includes `ignored.vulnerabilities` and `ignored.secrets`.
 
-The source scan scope is scanner-specific. With `secret-scan-scope: changes`, TruffleHog limits git scanning to the changed commit range, while Trivy still scans the current checked-out source tree. With `secret-scan-scope: full-history`, TruffleHog scans reachable git history, while Trivy still scans only the current branch's checked-out tree. When called from fast-feedback, the source scan checks out the same `checkout-version` ref as build, test, and promotion jobs. Trivy is not limited to `working-directory`, so shared manifests and related modules outside the P2P make target directory are still covered.
+The source scan scope is scanner-specific and repository-wide, not folder-scoped. With `secret-scan-scope: changes`, TruffleHog scans the changed git commit range across the repository, while Trivy source dependency vulnerability scanning/SCA scans the current checked-out source tree. With `secret-scan-scope: full-history`, TruffleHog scans reachable git history across the repository, while Trivy scans the current branch's checked-out source tree. When called from fast-feedback, the source scan checks out the same `checkout-version` ref as build, test, and promotion jobs. `working-directory` does not limit either source scanner, so shared manifests and related modules outside the P2P make target directory are still covered.
 
 ## Security ignore file
 
-The source security workflow reads one P2P-owned ignore file from the repository root: `.p2p-security-ignore.yaml`. If the file is absent, scans behave normally. If it is present but malformed, uses an unsupported schema version, omits required fields, has invalid shapes, or contains invalid expiry dates, the scan/report job fails.
+The source security workflow discovers every P2P-owned `.p2p-security-ignore.yaml` file in the repository. If no ignore files are present, scans behave normally. If any discovered ignore file is malformed, uses an unsupported schema version, omits required fields, has invalid shapes, contains invalid expiry dates, or has a source path filter that resolves outside the ignore file's directory, the scan/report job fails even when there are no findings under that directory.
 
-See [How to ignore security findings](../how-to/ignore-security-findings.md) for the v1 schema, matching rules, and secret ID guidance. The source scan uses the repository-root ignore file even when other P2P workflows use a non-root `working-directory`.
+See [How to ignore security findings](../how-to/ignore-security-findings.md) for the v1 schema, matching rules, and secret ID guidance. Source ignore discovery is independent of `working-directory` and `app-name`.
 
 ## Blocking policy
 

--- a/docs/tutorials/getting-started.md
+++ b/docs/tutorials/getting-started.md
@@ -121,7 +121,7 @@ See [Pipeline model](../explanation/pipeline-model.md) for the full picture of h
 
 ## Security scans
 
-Fast-feedback also calls source security scanning and image scanning automatically on each pull request and push. Source security scanning covers source dependency vulnerabilities, restricted or forbidden licenses, and git-tree secrets. Image scanning covers both known CVEs and embedded secrets. At this level, `security-scan-blocking-severity` defaults to `off`, so the scans report findings without blocking the workflow by default.
+Fast-feedback also calls source security scanning and image scanning automatically on each pull request and push. Source security scanning covers source dependency vulnerabilities and git-tree secrets. Image scanning covers both known CVEs and embedded secrets. At this level, `security-scan-blocking-severity` defaults to `off`, so the scans report findings without blocking the workflow by default.
 
 Look in the workflow summary and uploaded artifact for the details, and on pull requests you'll also get a sticky comment with the latest results.
 See [Image scanning](../explanation/image-scanning.md), [Secrets scanning](../explanation/secrets-scanning.md), and [Triage security findings](../how-to/triage-security-findings.md) for what each scan checks and how to respond.


### PR DESCRIPTION
## Summary
- Document source security scanning as repository-wide for TruffleHog and Trivy/SCA in fast-feedback and scheduled workflows.
- Discover all source .p2p-security-ignore.yaml files and scope each file's source entries to its directory tree, with nested source path filters resolved locally and escape attempts rejected.
- Preserve the active/ignored artifact split and keep image ignores to repository root plus selected working-directory.
