### PR TITLE
Skip non-image OCI artifacts in image scans

### DIFF
--- a/.github/scripts/image-scan-helpers.js
+++ b/.github/scripts/image-scan-helpers.js
@@ -4,6 +4,8 @@ const { execFileSync, spawnSync } = require('child_process');
 
 const VALID_STAGES = ['fast-feedback', 'extended-test', 'prod'];
 const NON_IMAGE_OCI_MEDIA_TYPES = new Set([
+  'application/tar+gzip',
+  'application/vnd.oci.empty.v1+json',
   'application/vnd.cncf.helm.chart.content.v1.tar+gzip',
   'application/vnd.cncf.helm.config.v1+json',
 ]);

--- a/.github/scripts/tests/image-scan-manifest.test.js
+++ b/.github/scripts/tests/image-scan-manifest.test.js
@@ -249,6 +249,104 @@ async function runManifestScript({ stage, vulnLines = [], secretLines = [], vuln
   assert.strictEqual(fs.readFileSync(allArtifacts.outputs['list-path'], 'utf8'), '');
   assert.strictEqual(allArtifacts.outputs['scan-target-count'], '0');
 
+  const attestationArtifact = await runPullScript(
+    ['europe-west2-docker.pkg.dev/project-a/tenant/tenant-a/prod/api:1.2.3'],
+    {
+      'europe-west2-docker.pkg.dev/project-a/tenant/tenant-a/prod/api:1.2.3': {
+        formatted: {
+          manifest: {
+            digest: 'sha256:attestation',
+            mediaType: 'application/vnd.oci.image.manifest.v1+json',
+          },
+          image: {
+            architecture: '',
+            os: '',
+            config: {},
+            rootfs: { type: '', diff_ids: null },
+          },
+        },
+        raw: {
+          schemaVersion: 2,
+          mediaType: 'application/vnd.oci.image.manifest.v1+json',
+          config: {
+            mediaType: 'application/vnd.oci.empty.v1+json',
+            digest: 'sha256:empty-config',
+            size: 2,
+          },
+          layers: [
+            {
+              mediaType: 'application/vnd.in-toto+json',
+              digest: 'sha256:provenance',
+              size: 1024,
+            },
+          ],
+        },
+      },
+    },
+  );
+  assert.deepStrictEqual(attestationArtifact.failures, []);
+  assert.deepStrictEqual(attestationArtifact.warnings, [
+    'Skipping europe-west2-docker.pkg.dev/project-a/tenant/tenant-a/prod/api:1.2.3; it is an OCI artifact, not a container image.',
+  ]);
+  assert.strictEqual(fs.readFileSync(attestationArtifact.outputs['list-path'], 'utf8'), '');
+  assert.strictEqual(attestationArtifact.outputs['scan-target-count'], '0');
+
+  const attestationArtifactFromFormattedInspect = await runPullScript(
+    ['europe-west2-docker.pkg.dev/project-a/tenant/tenant-a/prod/api:1.2.3'],
+    {
+      'europe-west2-docker.pkg.dev/project-a/tenant/tenant-a/prod/api:1.2.3': {
+        manifest: {
+          digest: 'sha256:attestation',
+          mediaType: 'application/vnd.oci.image.manifest.v1+json',
+          config: { mediaType: 'application/vnd.oci.empty.v1+json' },
+        },
+      },
+    },
+  );
+  assert.deepStrictEqual(attestationArtifactFromFormattedInspect.failures, []);
+  assert.deepStrictEqual(attestationArtifactFromFormattedInspect.warnings, [
+    'Skipping europe-west2-docker.pkg.dev/project-a/tenant/tenant-a/prod/api:1.2.3; it is an OCI artifact, not a container image.',
+  ]);
+  assert.strictEqual(fs.readFileSync(attestationArtifactFromFormattedInspect.outputs['list-path'], 'utf8'), '');
+  assert.strictEqual(attestationArtifactFromFormattedInspect.outputs['scan-target-count'], '0');
+
+  const mixedAttestationArtifact = await runPullScript(
+    [
+      'europe-west2-docker.pkg.dev/project-a/tenant/tenant-a/prod/api:1.2.3',
+      'europe-west2-docker.pkg.dev/project-a/tenant/tenant-a/prod/api-starter:1.2.3',
+    ],
+    {
+      'europe-west2-docker.pkg.dev/project-a/tenant/tenant-a/prod/api:1.2.3': {
+        manifest: { digest: 'sha256:resolved' },
+        image: { os: 'linux', architecture: 'amd64' },
+      },
+      'europe-west2-docker.pkg.dev/project-a/tenant/tenant-a/prod/api-starter:1.2.3': {
+        formatted: {
+          artifactType: 'application/tar+gzip',
+          manifest: {
+            digest: 'sha256:starter-content',
+            mediaType: 'application/vnd.oci.image.manifest.v1+json',
+          },
+          image: {
+            architecture: '',
+            os: '',
+            config: {},
+            rootfs: { type: '', diff_ids: null },
+          },
+        },
+      },
+    },
+  );
+  assert.deepStrictEqual(mixedAttestationArtifact.failures, []);
+  assert.deepStrictEqual(mixedAttestationArtifact.warnings, [
+    'Skipping europe-west2-docker.pkg.dev/project-a/tenant/tenant-a/prod/api-starter:1.2.3; it is an OCI artifact, not a container image.',
+  ]);
+  assert.deepStrictEqual(
+    fs.readFileSync(mixedAttestationArtifact.outputs['list-path'], 'utf8').trim(),
+    'europe-west2-docker.pkg.dev/project-a/tenant/tenant-a/prod/api:1.2.3\tlinux/amd64\tsha256:resolved',
+  );
+  assert.strictEqual(mixedAttestationArtifact.outputs['scan-target-count'], '1');
+
   const mixedEmptyImages = await runPullScript(
     [
       'europe-west2-docker.pkg.dev/project-a/tenant/tenant-a/prod/api:1.2.3',


### PR DESCRIPTION
## Summary

Image scans currently fail when a resolved OCI reference is an artifact rather than a runnable container image. This can happen for tarball artifacts or empty-config OCI metadata. Those references do not expose a usable container platform or digest, so the scanner setup aborts before it can scan any remaining valid images.

This change classifies those non-image OCI artifact media types as skippable scan inputs. Mixed scan lists still scan real container images and skip only the non-image artifacts; lists with no scannable container images complete as a no-op.

