### PR TITLE
Scope image scan Make fallback

### DIFF
--- a/.github/scripts/image-scan-helpers.js
+++ b/.github/scripts/image-scan-helpers.js
@@ -73,6 +73,7 @@ async function resolveImages({
     return execFileSyncImpl('make', ['--no-print-directory', target], {
       encoding: 'utf8',
       cwd: workingDirectory,
+      env: processEnvForMake(env),
     });
   }
 
@@ -80,6 +81,7 @@ async function resolveImages({
     try {
       execFileSyncImpl('make', ['--no-print-directory', '-q', target], {
         cwd: workingDirectory,
+        env: processEnvForMake(env),
         stdio: 'ignore',
       });
       return true;
@@ -113,6 +115,27 @@ async function resolveImages({
   core.setOutput('image-refs', refs.join('\n'));
   core.info('Resolved image references:');
   refs.forEach(r => core.info(`  - ${r}`));
+}
+
+function processEnvForMake(env) {
+  const valueFromEnv = (key, fallbackKey) => {
+    if (Object.prototype.hasOwnProperty.call(env, key)) return env[key];
+    if (fallbackKey && Object.prototype.hasOwnProperty.call(env, fallbackKey)) return env[fallbackKey];
+    return process.env[key];
+  };
+
+  const makeEnv = {
+    ...process.env,
+    ...env,
+  };
+  for (const [key, value] of [
+    ['P2P_TENANT_NAME', valueFromEnv('P2P_TENANT_NAME', 'TENANT_NAME')],
+    ['P2P_APP_NAME', valueFromEnv('P2P_APP_NAME')],
+    ['P2P_VERSION', valueFromEnv('P2P_VERSION', 'VERSION')],
+  ]) {
+    if (value !== undefined) makeEnv[key] = value;
+  }
+  return makeEnv;
 }
 
 async function pullImages({

--- a/.github/scripts/image-scan-helpers.js
+++ b/.github/scripts/image-scan-helpers.js
@@ -133,7 +133,11 @@ function processEnvForMake(env) {
     ['P2P_APP_NAME', valueFromEnv('P2P_APP_NAME')],
     ['P2P_VERSION', valueFromEnv('P2P_VERSION', 'VERSION')],
   ]) {
-    if (value !== undefined) makeEnv[key] = value;
+    if (value === undefined || value === '') {
+      delete makeEnv[key];
+    } else {
+      makeEnv[key] = value;
+    }
   }
   return makeEnv;
 }

--- a/.github/scripts/tests/image-ref-resolution.test.js
+++ b/.github/scripts/tests/image-ref-resolution.test.js
@@ -20,6 +20,9 @@ async function runCase(name, makeOutputs, envOverrides = {}) {
       VERSION: '1.2.3',
       WORKING_DIR: '/repo',
       GITHUB_WORKSPACE: '/repo',
+      P2P_TENANT_NAME: 'tenant-a',
+      P2P_APP_NAME: 'api',
+      P2P_VERSION: '1.2.3',
       ...envOverrides,
     },
     core: {
@@ -28,7 +31,7 @@ async function runCase(name, makeOutputs, envOverrides = {}) {
       setFailed: message => { failures.push(message); },
     },
     execFileSyncImpl(command, args, options) {
-      calls.push({ command, args, cwd: options.cwd });
+      calls.push({ command, args, cwd: options.cwd, env: options.env });
       assert.strictEqual(command, 'make', `${name}: command`);
       const target = args[args.length - 1];
       if (args.includes('-q')) {
@@ -63,6 +66,18 @@ async function runCase(name, makeOutputs, envOverrides = {}) {
       'europe-west2-docker.pkg.dev/project-a/tenant/tenant-a/fast-feedback/api:1.2.3',
       'europe-west2-docker.pkg.dev/project-a/tenant/tenant-a/fast-feedback/ui:1.2.3',
     ],
+  );
+  assert.deepStrictEqual(
+    fallback.calls.map(call => ({
+      p2pTenantName: call.env.P2P_TENANT_NAME,
+      p2pAppName: call.env.P2P_APP_NAME,
+      p2pVersion: call.env.P2P_VERSION,
+    })),
+    [
+      { p2pTenantName: 'tenant-a', p2pAppName: 'api', p2pVersion: '1.2.3' },
+      { p2pTenantName: 'tenant-a', p2pAppName: 'api', p2pVersion: '1.2.3' },
+    ],
+    'missing image-names falls back with P2P make context',
   );
 
   const inputImages = await runCase(

--- a/.github/scripts/tests/image-ref-resolution.test.js
+++ b/.github/scripts/tests/image-ref-resolution.test.js
@@ -10,21 +10,28 @@ async function runCase(name, makeOutputs, envOverrides = {}) {
   const infos = [];
   const failures = [];
   const make = target => makeOutputs[target] ?? null;
+  const env = {
+    PIPELINE_STAGE: 'fast-feedback',
+    REGION: 'europe-west2',
+    PROJECT_ID: 'project-a',
+    TENANT_NAME: 'tenant-a',
+    VERSION: '1.2.3',
+    WORKING_DIR: '/repo',
+    GITHUB_WORKSPACE: '/repo',
+    P2P_TENANT_NAME: 'tenant-a',
+    P2P_APP_NAME: 'api',
+    P2P_VERSION: '1.2.3',
+  };
+  for (const [key, value] of Object.entries(envOverrides)) {
+    if (value === undefined) {
+      delete env[key];
+    } else {
+      env[key] = value;
+    }
+  }
 
   await resolveImages({
-    env: {
-      PIPELINE_STAGE: 'fast-feedback',
-      REGION: 'europe-west2',
-      PROJECT_ID: 'project-a',
-      TENANT_NAME: 'tenant-a',
-      VERSION: '1.2.3',
-      WORKING_DIR: '/repo',
-      GITHUB_WORKSPACE: '/repo',
-      P2P_TENANT_NAME: 'tenant-a',
-      P2P_APP_NAME: 'api',
-      P2P_VERSION: '1.2.3',
-      ...envOverrides,
-    },
+    env,
     core: {
       setOutput: (key, value) => { outputs[key] = value; },
       info: message => { infos.push(message); },
@@ -95,6 +102,40 @@ async function runCase(name, makeOutputs, envOverrides = {}) {
     ],
   );
   assert.deepStrictEqual(inputImages.calls, [], 'image-names input wins: make is not called');
+
+  const omittedAppName = await runCase('empty app-name lets make defaults apply', {
+    'p2p-images': 'tenant-a\n',
+  }, { P2P_APP_NAME: '' });
+  assert.deepStrictEqual(omittedAppName.failures, [], 'empty app-name lets make defaults apply: no failures');
+  assert.strictEqual(
+    omittedAppName.outputs['image-refs'],
+    'europe-west2-docker.pkg.dev/project-a/tenant/tenant-a/fast-feedback/tenant-a:1.2.3',
+  );
+  assert.deepStrictEqual(
+    omittedAppName.calls.map(call => Object.prototype.hasOwnProperty.call(call.env, 'P2P_APP_NAME')),
+    [false, false],
+    'empty app-name is omitted from make env so Makefile ?= defaults can apply',
+  );
+
+  const fallbackMakeContext = await runCase('make context falls back to workflow env names', {
+    'p2p-images': 'api\n',
+  }, {
+    P2P_TENANT_NAME: undefined,
+    P2P_APP_NAME: undefined,
+    P2P_VERSION: undefined,
+  });
+  assert.deepStrictEqual(
+    fallbackMakeContext.calls.map(call => ({
+      p2pTenantName: call.env.P2P_TENANT_NAME,
+      hasP2pAppName: Object.prototype.hasOwnProperty.call(call.env, 'P2P_APP_NAME'),
+      p2pVersion: call.env.P2P_VERSION,
+    })),
+    [
+      { p2pTenantName: 'tenant-a', hasP2pAppName: false, p2pVersion: '1.2.3' },
+      { p2pTenantName: 'tenant-a', hasP2pAppName: false, p2pVersion: '1.2.3' },
+    ],
+    'make context falls back from TENANT_NAME and VERSION when P2P names are absent',
+  );
 
   const emptyInput = await runCase('empty image-names falls back', {
     'p2p-images': 'worker\n',

--- a/.github/workflows/internal-ci.yaml
+++ b/.github/workflows/internal-ci.yaml
@@ -172,6 +172,9 @@ jobs:
           tenant_name = 'tenant-name: $' + '{{ inputs.tenant-name }}'
           tenant_name_count = workflow.count(tenant_name)
           assert tenant_name_count == 4, f'expected source plus 3 scheduled tenant-name pass-throughs, got {tenant_name_count}'
+          assert 'P2P_TENANT_NAME: $' + '{{ inputs.tenant-name != ' in workflow
+          assert 'P2P_APP_NAME: $' + '{{ inputs.app-name }}' in workflow
+          assert 'unset P2P_APP_NAME' in workflow
 
           stage_workflow = Path('.github/workflows/p2p-workflow-security-image-scan-stage.yaml').read_text()
           assert 'blocking-severity: $' + '{{ inputs.security-scan-blocking-severity }}' in stage_workflow
@@ -217,6 +220,9 @@ jobs:
           assert "name: security-image-scan ($" + "{{ inputs.github_env != '' && format('{0}, {1}', inputs.pipeline-stage, inputs.github_env) || inputs.pipeline-stage }})" in workflow
           assert 'name: ' + "'security-image-scan ($" + '{{ inputs.github_env }})' not in workflow
           assert 'PIPELINE_STAGE: $' + '{{ inputs.pipeline-stage }}' in workflow
+          assert 'P2P_TENANT_NAME: $' + '{{ env.TENANT_NAME }}' in workflow
+          assert 'P2P_APP_NAME: $' + '{{ inputs.app-name }}' in workflow
+          assert 'P2P_VERSION: $' + '{{ inputs.version }}' in workflow
           assert 'header: security-image-scan-findings-$' + '{{ inputs.app-name || inputs.tenant-name || vars.TENANT_NAME }}-$' + '{{ inputs.pipeline-stage }}-$' + '{{ inputs.github_env || ' in workflow
           assert 'name: security-image-scan-reports-$' + '{{ inputs.pipeline-stage }}-$' + '{{ inputs.github_env || ' in workflow
           assert 'path: .p2p-workflow-src' in workflow

--- a/.github/workflows/p2p-workflow-image-scan.yaml
+++ b/.github/workflows/p2p-workflow-image-scan.yaml
@@ -154,6 +154,9 @@ jobs:
           PIPELINE_STAGE: ${{ inputs.pipeline-stage }}
           WORKING_DIR: ${{ inputs.working-directory }}
           IMAGE_NAMES: ${{ inputs.image-names }}
+          P2P_TENANT_NAME: ${{ env.TENANT_NAME }}
+          P2P_APP_NAME: ${{ inputs.app-name }}
+          P2P_VERSION: ${{ inputs.version }}
           P2P_IMAGE_SCAN_HELPERS: ${{ runner.temp }}/p2p-workflow-src/.github/scripts/image-scan-helpers.js
         with:
           script: |

--- a/.github/workflows/p2p-workflow-security-scan.yaml
+++ b/.github/workflows/p2p-workflow-security-scan.yaml
@@ -93,6 +93,8 @@ jobs:
           if [ -n "${IMAGE_NAMES//[[:space:],]/}" ]; then
             anchor=$(printf '%s' "$IMAGE_NAMES" | tr ',\n' '  ' | awk 'NF { print $1; exit }')
           else
+            if [ -z "${P2P_TENANT_NAME:-}" ]; then unset P2P_TENANT_NAME; fi
+            if [ -z "${P2P_APP_NAME:-}" ]; then unset P2P_APP_NAME; fi
             anchor=$(make --no-print-directory -C "$WORKING_DIR" p2p-images | awk 'NF { print $1; exit }')
           fi
           if [ -z "$anchor" ]; then

--- a/.github/workflows/p2p-workflow-security-scan.yaml
+++ b/.github/workflows/p2p-workflow-security-scan.yaml
@@ -86,6 +86,8 @@ jobs:
         env:
           IMAGE_NAMES: ${{ inputs.image-names }}
           WORKING_DIR: ${{ inputs.working-directory }}
+          P2P_TENANT_NAME: ${{ inputs.tenant-name != '' && inputs.tenant-name || vars.TENANT_NAME }}
+          P2P_APP_NAME: ${{ inputs.app-name }}
         run: |
           set -euo pipefail
           if [ -n "${IMAGE_NAMES//[[:space:],]/}" ]; then

--- a/docs/explanation/image-scanning.md
+++ b/docs/explanation/image-scanning.md
@@ -4,7 +4,7 @@ Image scanning is a two-tool stack. Trivy reports known CVEs in OS and language 
 
 ## What gets scanned and when
 
-For a given stage, the workflow starts from standard P2P image names from the `image-names` input when that input is set. Otherwise it runs `make p2p-images` in the configured working directory. Each image name is combined with that stage's registry path and the requested version, then the resulting references are inspected before scanning.
+For a given stage, the workflow starts from standard P2P image names from the `image-names` input when that input is set. Otherwise it runs `make p2p-images` in the configured working directory with the workflow's `P2P_TENANT_NAME`, `P2P_APP_NAME`, and `P2P_VERSION` context. Each image name is combined with that stage's registry path and the requested version, then the resulting references are inspected before scanning.
 
 Some P2P image lists include OCI references that are needed for build, promotion, or deployment but are not useful inputs for container scanners, such as Helm chart artifacts. Some apps also intentionally publish no scannable container image, or publish an empty `FROM scratch` image. Image scanning excludes known non-container OCI artifacts and confirmed empty container images before running Trivy or TruffleHog. If nothing scannable remains, the scan succeeds with zero findings. This keeps scanner failures meaningful: a skipped reference is logged as a warning, while scanner execution failures against scannable container images still fail the scan.
 

--- a/docs/how-to/enable-scheduled-security-scanning.md
+++ b/docs/how-to/enable-scheduled-security-scanning.md
@@ -51,7 +51,7 @@ To make scheduled scans block on findings, set `security-scan-blocking-severity`
 
 ## 3. Image discovery
 
-By default, the umbrella runs `make p2p-images` from `working-directory` and uses the first returned image name as the anchor for latest-version discovery. Each stage image scan then resolves its scan targets independently: it uses the explicit `image-names` input when provided, or runs `make p2p-images` from `working-directory` when `image-names` is empty.
+By default, the umbrella runs `make p2p-images` from `working-directory` and uses the first returned image name as the anchor for latest-version discovery. Each stage image scan then resolves its scan targets independently: it uses the explicit `image-names` input when provided, or runs `make p2p-images` from `working-directory` when `image-names` is empty. Fallback Make calls receive `P2P_TENANT_NAME` and `P2P_APP_NAME`, and image-scan target resolution also receives `P2P_VERSION`, so multi-app repositories can return an app-specific image list.
 
 If your repository cannot use `make p2p-images` for scheduled scans, pass `image-names` explicitly:
 

--- a/docs/reference/p2p-workflow-image-scan.md
+++ b/docs/reference/p2p-workflow-image-scan.md
@@ -14,7 +14,7 @@ Internal workflow called by [`p2p-workflow-fastfeedback`](p2p-workflow-fastfeedb
 | `version` | string | Yes | — | Image tag to scan. Used with each standard P2P image name to build the stage Artifact Registry reference. |
 | `github_env` | string | No | `''` | GitHub Environment used for environment-scoped variables and GCP auth. Required in practice — image pulls go through Workload Identity Federation bound to this environment. |
 | `tenant-name` | string | No | `''` | Tenant identifier. Falls back to `vars.TENANT_NAME` when empty. |
-| `app-name` | string | No | `''` | Application name used to scope sticky PR comments in multi-app repositories. It does not select security ignore files. Primary P2P workflow templates pass this through. When omitted by direct callers, comment scope falls back to `tenant-name`, then `vars.TENANT_NAME`. |
+| `app-name` | string | No | `''` | Application name used to scope sticky PR comments and the `make p2p-images` fallback in multi-app repositories. It does not select security ignore files. Primary P2P workflow templates pass this through. When omitted by direct callers, comment scope falls back to `tenant-name`, then `vars.TENANT_NAME`. |
 | `region` | string | No | `europe-west2` | GCP region for the Artifact Registry. Overridden by `vars.REGION` when set on the environment. |
 | `working-directory` | string | No | `.` | Directory from which `make p2p-images` is executed when `image-names` is empty. |
 | `image-names` | string | No | `''` | Newline-, comma-, or whitespace-separated list of standard P2P image names to scan. When set, this list is used instead of `make p2p-images`. |
@@ -68,7 +68,7 @@ The job runs under `environment: ${{ inputs.github_env }}` and authenticates to 
 
 ## Image resolution
 
-If `image-names` is set, the workflow splits it on commas or whitespace and treats exactly those standard P2P image names as scan candidates. If it is empty, the workflow runs `make p2p-images` in `working-directory` after checking out `checkout-version`; that target must print standard P2P image names with no registry and no tag. Each image name is combined with the registry path for `pipeline-stage` and the `version` input to form the full reference:
+If `image-names` is set, the workflow splits it on commas or whitespace and treats exactly those standard P2P image names as scan candidates. If it is empty, the workflow runs `make p2p-images` in `working-directory` after checking out `checkout-version`; that target must print standard P2P image names with no registry and no tag. The Make fallback receives `P2P_TENANT_NAME`, `P2P_APP_NAME`, and `P2P_VERSION` from the workflow inputs and resolved tenant context, so multi-app repositories can scope image discovery by `app-name`. Each image name is combined with the registry path for `pipeline-stage` and the `version` input to form the full reference:
 
 ```
 <region>-docker.pkg.dev/<project>/tenant/<tenant>/<pipeline-stage>/<image>:<version>

--- a/docs/reference/p2p-workflow-security-scan.md
+++ b/docs/reference/p2p-workflow-security-scan.md
@@ -36,8 +36,8 @@ jobs:
 | Name | Type | Required | Default | Description |
 |------|------|----------|---------|-------------|
 | `tenant-name` | string | No | `''` | Tenant identifier passed through to child workflows. Falls back to `vars.TENANT_NAME` when empty. |
-| `app-name` | string | No | `''` | Application name passed through to child security scans so sticky PR comments are scoped per app in multi-app repositories. Scheduled wrappers should set this to the application tenant name. |
-| `image-names` | string | No | `''` | Newline-, comma-, or whitespace-separated list of standard P2P image names. The first entry is the version-lookup anchor for each stage, and the full list is passed to each image scan. If empty, image scans fall back to `make p2p-images` in `working-directory`. |
+| `app-name` | string | No | `''` | Application name passed through to child security scans so sticky PR comments and `make p2p-images` fallback discovery are scoped per app in multi-app repositories. Scheduled wrappers should set this to the application tenant name. |
+| `image-names` | string | No | `''` | Newline-, comma-, or whitespace-separated list of standard P2P image names. The first entry is the version-lookup anchor for each stage, and the full list is passed to each image scan. If empty, image scans fall back to `make p2p-images` in `working-directory` with the workflow's P2P app context. |
 | `working-directory` | string | No | `.` | Working directory for `make p2p-images` when `image-names` is empty. |
 | `region` | string | No | `europe-west2` | GCP region; overridden by `vars.REGION`. |
 | `dry-run` | boolean | No | `false` | Passed through to child workflows; still resolves the anchor image from `image-names` or `make p2p-images`, then skips registry lookups and scans. |


### PR DESCRIPTION
## What changed

- Pass `P2P_TENANT_NAME`, `P2P_APP_NAME`, and `P2P_VERSION` into image-scan `make p2p-images` fallback resolution.
- Pass app context into the scheduled security scan anchor-image fallback.
- Add resolver fixture coverage to assert fallback Make calls receive the P2P app context while explicit `image-names` still bypasses Make.
- Update image scan and scheduled security scan docs to document fallback scoping.

## Why

Multi-image tenants can run several P2P image-scan lanes from the same working directory with different `app-name` values. Without `P2P_APP_NAME` on the fallback Make invocation, `make p2p-images` can return sibling images for another lane, causing scans to race against tags that have not been pushed yet.

