### PR TITLE
Update security scanner versions

### DIFF
--- a/.github/workflows/p2p-workflow-image-scan.yaml
+++ b/.github/workflows/p2p-workflow-image-scan.yaml
@@ -174,17 +174,17 @@ jobs:
 
       - name: Install Trivy
         if: ${{ inputs.dry-run == false }}
-        uses: aquasecurity/setup-trivy@v0.2.6
+        uses: aquasecurity/setup-trivy@v0.3.1
         with:
-          version: v0.70.0
+          version: v0.71.2
           cache: true
 
       - name: Install TruffleHog
         if: ${{ inputs.dry-run == false }}
         shell: bash
         run: |
-          curl -sSfL https://raw.githubusercontent.com/trufflesecurity/trufflehog/v3.95.3/scripts/install.sh \
-            | sh -s -- -b "$RUNNER_TEMP" v3.95.3
+          curl -sSfL https://raw.githubusercontent.com/trufflesecurity/trufflehog/v3.95.6/scripts/install.sh \
+            | sh -s -- -b "$RUNNER_TEMP" v3.95.6
           echo "$RUNNER_TEMP" >> "$GITHUB_PATH"
 
       - id: scan

--- a/.github/workflows/p2p-workflow-source-security-scan.yaml
+++ b/.github/workflows/p2p-workflow-source-security-scan.yaml
@@ -93,8 +93,8 @@ jobs:
         if: ${{ inputs.dry-run == false }}
         shell: bash
         run: |
-          curl -sSfL https://raw.githubusercontent.com/trufflesecurity/trufflehog/v3.95.3/scripts/install.sh \
-            | sh -s -- -b "$RUNNER_TEMP" v3.95.3
+          curl -sSfL https://raw.githubusercontent.com/trufflesecurity/trufflehog/v3.95.6/scripts/install.sh \
+            | sh -s -- -b "$RUNNER_TEMP" v3.95.6
           echo "$RUNNER_TEMP" >> "$GITHUB_PATH"
 
       - id: scan
@@ -171,9 +171,9 @@ jobs:
 
       - name: Install Trivy
         if: ${{ inputs.dry-run == false }}
-        uses: aquasecurity/setup-trivy@v0.2.6
+        uses: aquasecurity/setup-trivy@v0.3.1
         with:
-          version: v0.70.0
+          version: v0.71.2
           cache: true
 
       - id: scan


### PR DESCRIPTION
## Summary
- update Trivy setup action to v0.3.1
- update Trivy CLI to v0.71.2
- update TruffleHog to v3.95.6 in source and image scan workflows

## Testing
- git diff --check
- verified no stale v0.70.0, v3.95.3, or setup-trivy@v0.2.6 pins remain