### PR TITLE
Make security severity off report-only

### DIFF
--- a/.github/scripts/tests/image-security-ignore-report.test.js
+++ b/.github/scripts/tests/image-security-ignore-report.test.js
@@ -527,18 +527,22 @@ function readStatusStepNames(workflowPath) {
     .filter(line => line.includes('Output security risk:'));
 }
 
-function assertWorkflowEnforcesScanStatus(workflowPath, outputName) {
+function assertWorkflowEnforcesScanStatusWhenBlockingEnabled(workflowPath, outputName) {
   const workflow = fs.readFileSync(workflowPath, 'utf8');
+  assert(workflow.includes('BLOCKING_SEVERITY: ${{ inputs.blocking-severity }}'));
   assert(workflow.includes(`SCAN_STATUS: \${{ needs.${outputName}.outputs.scan-status || 'failed' }}`));
   assert(workflow.includes('if [ "${SCAN_STATUS}" != "ok" ]; then'));
+  assert(workflow.includes('if [ "${BLOCKING_SEVERITY}" = "off" ]; then'));
+  assert(workflow.includes('blocking-severity=off, so scanner status does not fail the workflow'));
   assert(workflow.includes('Security scan did not complete successfully.'));
 }
 
-function assertImagePolicyFailsOnAnyFindingButOnlyBlocksOnBlockingFindings(workflowPath) {
+function assertImagePolicyFailsOnlyOnBlockingFindings(workflowPath) {
   const workflow = fs.readFileSync(workflowPath, 'utf8');
-  assert(workflow.includes("continue-on-error: ${{ inputs.blocking-severity == 'off' || (needs.security-image-scan.outputs.blocking-count == '0' && needs.security-image-scan.outputs.secret-blocking-count == '0') }}"));
-  assert(workflow.includes('elif [ "${TOTAL:-0}" -gt 0 ] || [ "${SECRET_TOTAL:-0}" -gt 0 ]; then'));
-  assert(workflow.includes('Security finding(s) detected below blocking-severity=${BLOCKING_SEVERITY}; this policy job is allowed to fail without failing the workflow.'));
+  assert(!workflow.includes('continue-on-error: ${{ inputs.blocking-severity =='));
+  assert(workflow.includes('if [ "${BLOCKING:-0}" -gt 0 ] || [ "${SECRET_BLOCKING:-0}" -gt 0 ]; then'));
+  assert(!workflow.includes('elif [ "${TOTAL:-0}" -gt 0 ] || [ "${SECRET_TOTAL:-0}" -gt 0 ]; then'));
+  assert(!workflow.includes('Security finding(s) detected below blocking-severity=${BLOCKING_SEVERITY}; this policy job is allowed to fail without failing the workflow.'));
 }
 
 function assertLatestImageLookupDoesNotRequireCallerCheckout(workflowPath) {
@@ -1122,8 +1126,8 @@ async function runZeroScanTargetReport() {
   assert.deepStrictEqual(imageStatusSteps, [
     '      - name: "Output security risk: ${{ needs.security-image-scan.outputs.security-risk || \'unknown\' }}; scan: ${{ needs.security-image-scan.outputs.scan-status || \'failed\' }}"',
   ]);
-  assertWorkflowEnforcesScanStatus(path.resolve(__dirname, '../../workflows/p2p-workflow-image-scan.yaml'), 'security-image-scan');
-  assertImagePolicyFailsOnAnyFindingButOnlyBlocksOnBlockingFindings(path.resolve(__dirname, '../../workflows/p2p-workflow-image-scan.yaml'));
+  assertWorkflowEnforcesScanStatusWhenBlockingEnabled(path.resolve(__dirname, '../../workflows/p2p-workflow-image-scan.yaml'), 'security-image-scan');
+  assertImagePolicyFailsOnlyOnBlockingFindings(path.resolve(__dirname, '../../workflows/p2p-workflow-image-scan.yaml'));
   assertLatestImageLookupDoesNotRequireCallerCheckout(path.resolve(__dirname, '../../workflows/p2p-get-latest-image.yaml'));
   console.log('image security ignore report fixtures passed');
 })().catch(error => {

--- a/.github/scripts/tests/source-security-ignore-report.test.js
+++ b/.github/scripts/tests/source-security-ignore-report.test.js
@@ -254,18 +254,22 @@ function readStatusStepNames(workflowPath) {
     .filter(line => line.includes('Output security risk:'));
 }
 
-function assertWorkflowEnforcesScanStatus(workflowPath, outputName) {
+function assertWorkflowEnforcesScanStatusWhenBlockingEnabled(workflowPath, outputName) {
   const workflow = fs.readFileSync(workflowPath, 'utf8');
+  assert(workflow.includes('BLOCKING_SEVERITY: ${{ inputs.blocking-severity }}'));
   assert(workflow.includes(`SCAN_STATUS: \${{ needs.${outputName}.outputs.scan-status || 'failed' }}`));
   assert(workflow.includes('if [ "${SCAN_STATUS}" != "ok" ]; then'));
+  assert(workflow.includes('if [ "${BLOCKING_SEVERITY}" = "off" ]; then'));
+  assert(workflow.includes('blocking-severity=off, so scanner status does not fail the workflow'));
   assert(workflow.includes('Security scan did not complete successfully.'));
 }
 
-function assertSourcePolicyFailsOnAnyFindingButOnlyBlocksOnBlockingFindings(workflowPath) {
+function assertSourcePolicyFailsOnlyOnBlockingFindings(workflowPath) {
   const workflow = fs.readFileSync(workflowPath, 'utf8');
-  assert(workflow.includes("continue-on-error: ${{ inputs.blocking-severity == 'off' || (needs.security-source-report.outputs.vulnerability-blocking == '0' && needs.security-source-report.outputs.secret-blocking == '0') }}"));
-  assert(workflow.includes('elif [ "${VULN_TOTAL:-0}" -gt 0 ] || [ "${SECRET_TOTAL:-0}" -gt 0 ]; then'));
-  assert(workflow.includes('Security finding(s) detected below blocking-severity=${BLOCKING_SEVERITY}; this policy job is allowed to fail without failing the workflow.'));
+  assert(!workflow.includes('continue-on-error: ${{ inputs.blocking-severity =='));
+  assert(workflow.includes('if [ "${VULN_BLOCKING:-0}" -gt 0 ] || [ "${SECRET_BLOCKING:-0}" -gt 0 ]; then'));
+  assert(!workflow.includes('elif [ "${VULN_TOTAL:-0}" -gt 0 ] || [ "${SECRET_TOTAL:-0}" -gt 0 ]; then'));
+  assert(!workflow.includes('Security finding(s) detected below blocking-severity=${BLOCKING_SEVERITY}; this policy job is allowed to fail without failing the workflow.'));
 }
 
 function assertSourceTrivyReportsUnknownSeverity(workflowPath) {
@@ -1210,8 +1214,8 @@ async function runReportWithMissingTruffleHogOutput() {
   assert.deepStrictEqual(sourceStatusSteps, [
     '      - name: "Output security risk: ${{ needs.security-source-report.outputs.security-risk || \'unknown\' }}; scan: ${{ needs.security-source-report.outputs.scan-status || \'failed\' }}"',
   ]);
-  assertWorkflowEnforcesScanStatus(path.resolve(__dirname, '../../workflows/p2p-workflow-source-security-scan.yaml'), 'security-source-report');
-  assertSourcePolicyFailsOnAnyFindingButOnlyBlocksOnBlockingFindings(path.resolve(__dirname, '../../workflows/p2p-workflow-source-security-scan.yaml'));
+  assertWorkflowEnforcesScanStatusWhenBlockingEnabled(path.resolve(__dirname, '../../workflows/p2p-workflow-source-security-scan.yaml'), 'security-source-report');
+  assertSourcePolicyFailsOnlyOnBlockingFindings(path.resolve(__dirname, '../../workflows/p2p-workflow-source-security-scan.yaml'));
   assertSourceTrivyReportsUnknownSeverity(path.resolve(__dirname, '../../workflows/p2p-workflow-source-security-scan.yaml'));
   for (const mode of ['missing', 'empty', 'invalid']) {
     await assert.rejects(

--- a/.github/workflows/p2p-workflow-image-scan.yaml
+++ b/.github/workflows/p2p-workflow-image-scan.yaml
@@ -279,10 +279,22 @@ jobs:
       - name: Enforce scanner execution status
         shell: bash
         env:
+          BLOCKING_SEVERITY: ${{ inputs.blocking-severity }}
           SCAN_STATUS: ${{ needs.security-image-scan.outputs.scan-status || 'failed' }}
         run: |
           set -euo pipefail
+          case "${BLOCKING_SEVERITY}" in
+            off|low|medium|high|critical) ;;
+            *)
+              echo "::error::blocking-severity must be one of: off, low, medium, high, critical. Got: ${BLOCKING_SEVERITY}"
+              exit 1
+              ;;
+          esac
           if [ "${SCAN_STATUS}" != "ok" ]; then
+            if [ "${BLOCKING_SEVERITY}" = "off" ]; then
+              echo "::warning::Security scan did not complete successfully. blocking-severity=off, so scanner status does not fail the workflow. scan-status=${SCAN_STATUS}"
+              exit 0
+            fi
             echo "::error::Security scan did not complete successfully. scan-status=${SCAN_STATUS}"
             exit 1
           fi
@@ -292,7 +304,6 @@ jobs:
     runs-on: ubuntu-24.04
     needs: [security-image-scan]
     if: ${{ always() && inputs.dry-run == false }}
-    continue-on-error: ${{ inputs.blocking-severity == 'off' || (needs.security-image-scan.outputs.blocking-count == '0' && needs.security-image-scan.outputs.secret-blocking-count == '0') }}
     timeout-minutes: 1
     steps:
       - name: "Output security risk: ${{ needs.security-image-scan.outputs.security-risk || 'unknown' }}; scan: ${{ needs.security-image-scan.outputs.scan-status || 'failed' }}"
@@ -318,15 +329,7 @@ jobs:
           echo "Trivy: total=${TOTAL:-0}, blocking=${BLOCKING:-0}"
           echo "TruffleHog: total=${SECRET_TOTAL:-0}, blocking=${SECRET_BLOCKING:-0}"
           echo "blocking-severity=${BLOCKING_SEVERITY}"
-          if [ "${BLOCKING_SEVERITY}" = "off" ]; then
-            if [ "${TOTAL:-0}" -gt 0 ] || [ "${SECRET_TOTAL:-0}" -gt 0 ]; then
-              echo "::error::Security finding(s) detected. blocking-severity=off, so this policy job is allowed to fail without failing the workflow."
-              exit 1
-            fi
-          elif [ "${BLOCKING:-0}" -gt 0 ] || [ "${SECRET_BLOCKING:-0}" -gt 0 ]; then
+          if [ "${BLOCKING:-0}" -gt 0 ] || [ "${SECRET_BLOCKING:-0}" -gt 0 ]; then
             echo "::error::Security finding(s) at or above blocking-severity=${BLOCKING_SEVERITY} detected."
-            exit 1
-          elif [ "${TOTAL:-0}" -gt 0 ] || [ "${SECRET_TOTAL:-0}" -gt 0 ]; then
-            echo "::error::Security finding(s) detected below blocking-severity=${BLOCKING_SEVERITY}; this policy job is allowed to fail without failing the workflow."
             exit 1
           fi

--- a/.github/workflows/p2p-workflow-source-security-scan.yaml
+++ b/.github/workflows/p2p-workflow-source-security-scan.yaml
@@ -306,10 +306,22 @@ jobs:
       - name: Enforce scanner execution status
         shell: bash
         env:
+          BLOCKING_SEVERITY: ${{ inputs.blocking-severity }}
           SCAN_STATUS: ${{ needs.security-source-report.outputs.scan-status || 'failed' }}
         run: |
           set -euo pipefail
+          case "${BLOCKING_SEVERITY}" in
+            off|low|medium|high|critical) ;;
+            *)
+              echo "::error::blocking-severity must be one of: off, low, medium, high, critical. Got: ${BLOCKING_SEVERITY}"
+              exit 1
+              ;;
+          esac
           if [ "${SCAN_STATUS}" != "ok" ]; then
+            if [ "${BLOCKING_SEVERITY}" = "off" ]; then
+              echo "::warning::Security scan did not complete successfully. blocking-severity=off, so scanner status does not fail the workflow. scan-status=${SCAN_STATUS}"
+              exit 0
+            fi
             echo "::error::Security scan did not complete successfully. scan-status=${SCAN_STATUS}"
             exit 1
           fi
@@ -319,7 +331,6 @@ jobs:
     runs-on: ubuntu-24.04
     needs: [security-source-report]
     if: ${{ always() && inputs.dry-run == false }}
-    continue-on-error: ${{ inputs.blocking-severity == 'off' || (needs.security-source-report.outputs.vulnerability-blocking == '0' && needs.security-source-report.outputs.secret-blocking == '0') }}
     timeout-minutes: 1
     steps:
       - name: "Output security risk: ${{ needs.security-source-report.outputs.security-risk || 'unknown' }}; scan: ${{ needs.security-source-report.outputs.scan-status || 'failed' }}"
@@ -347,15 +358,7 @@ jobs:
           echo "Trivy restricted/forbidden licenses: total=${LICENSE_TOTAL:-0}, blocking=0"
           echo "TruffleHog secrets: total=${SECRET_TOTAL:-0}, blocking=${SECRET_BLOCKING:-0}"
           echo "blocking-severity=${BLOCKING_SEVERITY}"
-          if [ "${BLOCKING_SEVERITY}" = "off" ]; then
-            if [ "${VULN_TOTAL:-0}" -gt 0 ] || [ "${SECRET_TOTAL:-0}" -gt 0 ]; then
-              echo "::error::Security finding(s) detected. blocking-severity=off, so this policy job is allowed to fail without failing the workflow."
-              exit 1
-            fi
-          elif [ "${VULN_BLOCKING:-0}" -gt 0 ] || [ "${SECRET_BLOCKING:-0}" -gt 0 ]; then
+          if [ "${VULN_BLOCKING:-0}" -gt 0 ] || [ "${SECRET_BLOCKING:-0}" -gt 0 ]; then
             echo "::error::Security finding(s) at or above blocking-severity=${BLOCKING_SEVERITY} detected."
-            exit 1
-          elif [ "${VULN_TOTAL:-0}" -gt 0 ] || [ "${SECRET_TOTAL:-0}" -gt 0 ]; then
-            echo "::error::Security finding(s) detected below blocking-severity=${BLOCKING_SEVERITY}; this policy job is allowed to fail without failing the workflow."
             exit 1
           fi

--- a/docs/explanation/secrets-scanning.md
+++ b/docs/explanation/secrets-scanning.md
@@ -9,7 +9,7 @@ P2P provides platform-managed secrets scanning so application teams do not have 
 | PR / push | `changes` - the delta (only commits introduced by the PR or push) | `p2p-workflow-fastfeedback` | No (opt in with `security-scan-blocking-severity: low`, `medium`, `high`, or `critical`) |
 | Cron | `full-history` - every reachable commit | `p2p-workflow-security-scan` wrapper | No |
 
-The two modes serve different purposes: the PR/push mode is a **gate candidate** that surfaces new secrets as they are introduced and can be promoted to a hard gate by setting `security-scan-blocking-severity` to a non-`off` threshold; the scheduled mode is a **monitoring signal** that surfaces legacy findings and re-checks dormant repositories. When blocking is enabled, verified secrets are treated as `critical`. The same source security report also shows source vulnerabilities.
+The two modes serve different purposes: the PR/push mode is a **gate candidate** that surfaces new secrets as they are introduced and can be promoted to a hard gate by setting `security-scan-blocking-severity` to a non-`off` threshold; the scheduled mode is a **monitoring signal** that surfaces legacy findings and re-checks dormant repositories. With the default `off` threshold, findings and scanner issues are report-only. When blocking is enabled, scanner output must be complete and verified secrets are treated as `critical`. The same source security report also shows source vulnerabilities.
 
 ## See also
 

--- a/docs/reference/p2p-workflow-extended-test.md
+++ b/docs/reference/p2p-workflow-extended-test.md
@@ -42,7 +42,7 @@ This workflow runs image scanning before promotion. The image scan authenticates
 | `tenant-name` | `string` | No | `''` | Tenant name passed to all make targets. |
 | `skip-subnamespaces-create` | `boolean` | No | `false` | Skips creating subnamespaces before running make targets. |
 | `artifacts` | `string` | No | `''` | YAML-formatted map of make target names to artifact paths. Paths matching each active command are uploaded after that command runs. |
-| `security-scan-blocking-severity` | `string` | No | `off` | Minimum security-image-scan finding severity that blocks the workflow: `off`, `low`, `medium`, `high`, or `critical`. Verified image secrets are treated as `critical`. The policy job fails on active findings, but the workflow continues when findings are below the blocking threshold. |
+| `security-scan-blocking-severity` | `string` | No | `off` | Minimum security-image-scan finding severity that blocks the workflow: `off`, `low`, `medium`, `high`, or `critical`. `off` is report-only and does not fail the workflow for findings or incomplete scanner output. When blocking is enabled, scanner output must be complete and verified image secrets are treated as `critical`. |
 
 ## Secrets
 
@@ -74,7 +74,8 @@ security-image-scan    (independent of run-tests; runs in parallel)
               Only runs on main-branch.
               checkout-version = version-prefix + version.
               Blocks the workflow on findings at or above
-              security-scan-blocking-severity (default: off).
+              security-scan-blocking-severity, and on incomplete scanner output
+              when that threshold is not off.
 
 notify-failure  (needs: run-tests, security-image-scan, promote; runs on main-branch when any job fails)
 ```

--- a/docs/reference/p2p-workflow-fastfeedback.md
+++ b/docs/reference/p2p-workflow-fastfeedback.md
@@ -46,7 +46,7 @@ Grant `pull-requests: write` when the workflow runs on pull requests so source a
 | `skip-fastfeedback-integration-on-prs` | `boolean` | No | `false` | When `true`, skips the `integration-test` job on pull requests (runs unconditionally on main or tags). |
 | `skip-subnamespaces-create` | `boolean` | No | `false` | Skips creating subnamespaces before running make targets. |
 | `artifacts` | `string` | No | `''` | YAML-formatted map of make target names to artifact paths. Paths matching each active command are uploaded after that command runs. |
-| `security-scan-blocking-severity` | `string` | No | `off` | Minimum security finding severity that blocks the workflow: `off`, `low`, `medium`, `high`, or `critical`. When blocking is enabled, verified secrets are treated as `critical`. Policy jobs fail on active findings, but the workflow continues when findings are below the blocking threshold. |
+| `security-scan-blocking-severity` | `string` | No | `off` | Minimum security finding severity that blocks the workflow: `off`, `low`, `medium`, `high`, or `critical`. `off` is report-only and does not fail the workflow for findings or incomplete scanner output. When blocking is enabled, scanner output must be complete and verified secrets are treated as `critical`. |
 
 ## Secrets
 
@@ -80,7 +80,8 @@ security-image-scan           (needs: build)
                      Calls p2p-workflow-image-scan against the built images.
                      Checks out the same checkout-version ref for image target resolution.
                      Blocks the workflow on findings at or above
-                     security-scan-blocking-severity (default: off).
+                     security-scan-blocking-severity, and on incomplete scanner
+                     output when that threshold is not off.
 
 security-source-scan  (independent of build; runs in parallel)
                       Calls p2p-workflow-source-security-scan with secret-scan-scope: changes.
@@ -90,7 +91,8 @@ security-source-scan  (independent of build; runs in parallel)
                       Reports source vulnerabilities and git-tree secrets.
                       Blocks only on vulnerabilities at or above
                       security-scan-blocking-severity or verified secrets when the
-                      threshold is not off.
+                      threshold is not off. Also blocks on incomplete scanner
+                      output when that threshold is not off.
 
 notify-failure       (needs: all jobs; runs on main-branch when any job fails)
 ```

--- a/docs/reference/p2p-workflow-image-scan.md
+++ b/docs/reference/p2p-workflow-image-scan.md
@@ -1,6 +1,6 @@
 # p2p-workflow-image-scan
 
-> Scans every scannable container image resolved by the repository's P2P image targets for known vulnerabilities (Trivy) and embedded secrets (TruffleHog). Produces a workflow summary, optionally posts a sticky PR comment on `pull_request` events, and uploads a `security-image-scan-reports-<stage>-<github_env>` artifact. The `security-image-policy` job fails on active vulnerability or secret findings; the configured blocking severity controls whether that policy failure fails the workflow.
+> Scans every scannable container image resolved by the repository's P2P image targets for known vulnerabilities (Trivy) and embedded secrets (TruffleHog). Produces a workflow summary, optionally posts a sticky PR comment on `pull_request` events, and uploads a `security-image-scan-reports-<stage>-<github_env>` artifact. The `security-image-policy` job fails only on findings at or above the configured blocking severity.
 
 ## Usage
 
@@ -20,7 +20,7 @@ Internal workflow called by [`p2p-workflow-fastfeedback`](p2p-workflow-fastfeedb
 | `image-names` | string | No | `''` | Newline-, comma-, or whitespace-separated list of standard P2P image names to scan. When set, this list is used instead of `make p2p-images`. |
 | `dry-run` | boolean | No | `false` | When `true`, still checks out the repo and resolves image names from `image-names` or `make p2p-images`, then skips GCP auth, registry login, image pulls, scanner installs, scans, sticky PR comment, artifact upload, and policy step. The `Build report` step still runs and produces a "Scan skipped" summary. Dry-run still parses the repository-root and selected `working-directory` `.p2p-security-ignore.yaml` files, so a malformed selected ignore file can fail report generation. |
 | `checkout-version` | string | No | `''` | Git ref to check out before resolving image names. Ignored when `dry-run` is `true`; the workflow checks out the default ref. |
-| `blocking-severity` | string | No | `off` | Minimum finding severity that blocks the workflow: `off`, `low`, `medium`, `high`, or `critical`. When blocking is enabled, verified image secrets are treated as `critical`. The `security-image-policy` job fails on active vulnerability or secret findings, but the workflow continues when findings are below the blocking threshold. |
+| `blocking-severity` | string | No | `off` | Minimum finding severity that blocks the workflow: `off`, `low`, `medium`, `high`, or `critical`. `off` is report-only and does not fail the workflow for findings or incomplete scanner output. When blocking is enabled, scanner output must be complete and verified image secrets are treated as `critical`. |
 | `ignore-unfixed` | boolean | No | `true` | When `true`, passes `--ignore-unfixed` to Trivy — only vulnerabilities with a fixed version are reported. |
 | `timeout-minutes` | number | No | `20` | Job timeout. |
 
@@ -74,7 +74,7 @@ If `image-names` is set, the workflow splits it on commas or whitespace and trea
 <region>-docker.pkg.dev/<project>/tenant/<tenant>/<pipeline-stage>/<image>:<version>
 ```
 
-Before running Trivy or TruffleHog, the workflow inspects each resolved reference and platform-specific manifest. It excludes OCI artifacts that are known not to be container images, currently Helm chart artifacts, and excludes confirmed empty container images whose raw image manifest has a Docker/OCI image config and explicit `layers: []`. Skipped references are logged as warnings and do not produce Trivy reports, TruffleHog reports, or `manifest.json` entries. Apps do not have to publish OCI images or a scannable container image; if no image refs are resolved or no scannable image targets remain, the image scan completes successfully with zero findings. Scanner execution failures for remaining scan targets still fail the scan.
+Before running Trivy or TruffleHog, the workflow inspects each resolved reference and platform-specific manifest. It excludes OCI artifacts that are known not to be container images, currently Helm chart artifacts, and excludes confirmed empty container images whose raw image manifest has a Docker/OCI image config and explicit `layers: []`. Skipped references are logged as warnings and do not produce Trivy reports, TruffleHog reports, or `manifest.json` entries. Apps do not have to publish OCI images or a scannable container image; if no image refs are resolved or no scannable image targets remain, the image scan completes successfully with zero findings. Scanner execution failures for remaining scan targets fail the workflow when `blocking-severity` is not `off`.
 
 If neither `image-names` nor `p2p-images` produces candidate names, or if all candidate references are excluded as non-scannable, the image scan completes successfully with zero findings.
 

--- a/docs/reference/p2p-workflow-prod.md
+++ b/docs/reference/p2p-workflow-prod.md
@@ -49,7 +49,7 @@ This workflow runs image scanning before deployment. The image scan authenticate
 | `app-name` | `string` | No | `''` | Application name. Must equal the tenant name (each application has its own application tenant). Also scopes image security sticky PR comments so multi-app repositories do not overwrite comments between apps. |
 | `tenant-name` | `string` | No | `''` | Tenant name passed to the make target. |
 | `skip-subnamespaces-create` | `boolean` | No | `false` | Skips creating subnamespaces before running the make target. |
-| `security-scan-blocking-severity` | `string` | No | `off` | Minimum security-image-scan finding severity that blocks the workflow: `off`, `low`, `medium`, `high`, or `critical`. Verified image secrets are treated as `critical`. The policy job fails on active findings, but the workflow continues when findings are below the blocking threshold. |
+| `security-scan-blocking-severity` | `string` | No | `off` | Minimum security-image-scan finding severity that blocks the workflow: `off`, `low`, `medium`, `high`, or `critical`. `off` is report-only and does not fail the workflow for findings or incomplete scanner output. When blocking is enabled, scanner output must be complete and verified image secrets are treated as `critical`. |
 
 ## Secrets
 
@@ -75,7 +75,8 @@ validate-version
                 Only runs on main-branch.
                 checkout-version = version-prefix + version.
                 Blocks the workflow on findings at or above
-                security-scan-blocking-severity (default: off).
+                security-scan-blocking-severity, and on incomplete scanner output
+                when that threshold is not off.
 └── prod-deploy (needs: security-image-scan)
                 Runs p2p-prod make target.
                 Only runs on main-branch after security-image-scan succeeds.

--- a/docs/reference/p2p-workflow-security-scan.md
+++ b/docs/reference/p2p-workflow-security-scan.md
@@ -42,7 +42,7 @@ jobs:
 | `region` | string | No | `europe-west2` | GCP region; overridden by `vars.REGION`. |
 | `dry-run` | boolean | No | `false` | Passed through to child workflows; still resolves the anchor image from `image-names` or `make p2p-images`, then skips registry lookups and scans. |
 | `checkout-version` | string | No | `''` | Internal consistency input for child checkouts. Application wrappers should normally omit it. |
-| `security-scan-blocking-severity` | string | No | `off` | Minimum security finding severity that blocks the umbrella workflow: `off`, `low`, `medium`, `high`, or `critical`. When blocking is enabled, verified secrets are treated as `critical`. Child policy jobs fail on active findings, but the umbrella workflow continues when findings are below the blocking threshold. |
+| `security-scan-blocking-severity` | string | No | `off` | Minimum security finding severity that blocks the umbrella workflow: `off`, `low`, `medium`, `high`, or `critical`. `off` is report-only and does not fail the workflow for findings or incomplete scanner output. When blocking is enabled, scanner output must be complete and verified secrets are treated as `critical`. |
 | `timeout-minutes` | number | No | `30` | Timeout for the `security-source-scan` job. security-image-scan jobs use their own default. |
 
 ## Secrets
@@ -59,7 +59,7 @@ jobs:
 None. Results are surfaced via:
 
 - Each child job's workflow summary (`$GITHUB_STEP_SUMMARY`).
-- On non-dry-run source scans where report generation completes, the `security-source-scan-findings` artifact from the security-source-scan job. It contains redacted TruffleHog output, raw Trivy filesystem output when available, and normalized merged JSON. Scheduled source scanning is repository-wide: TruffleHog scans reachable git history and Trivy source dependency vulnerability scanning/SCA scans the current branch's checked-out source tree. Scanner warnings or incomplete scanner output still fail the `security-source-scan-status-policy` job.
+- On non-dry-run source scans where report generation completes, the `security-source-scan-findings` artifact from the security-source-scan job. It contains redacted TruffleHog output, raw Trivy filesystem output when available, and normalized merged JSON. Scheduled source scanning is repository-wide: TruffleHog scans reachable git history and Trivy source dependency vulnerability scanning/SCA scans the current branch's checked-out source tree. Scanner warnings or incomplete scanner output fail the `security-source-scan-status-policy` job only when `security-scan-blocking-severity` is not `off`.
 - On successful non-dry-run image scans where a latest image tag is found and at least one scannable container image is available, the `security-image-scan-reports-<stage>-<github_env>` artifact from each security-image-scan job. Each artifact contains root `manifest.json`, `trivy/` vulnerability JSON reports, and `trufflehog-image/` secret JSON-lines reports for scanned image/platform pairs. `manifest.json` records the P2P stage (`fast-feedback`, `extended-test`, or `prod`) and is the supported artifact index.
 
 ## Job Graph
@@ -73,7 +73,7 @@ security-resolve-anchor-image
 security-source-scan                                   (independent; runs in parallel)
 ```
 
-Each matrix entry calls an internal stage workflow that first discovers the latest version for that stage/environment and then scans that exact version. The security-source-scan job runs in parallel with the per-stage matrices. For source scans, `secret-scan-scope: full-history` applies to repository-wide TruffleHog git scanning; Trivy scans the current checked-out branch tree and is not limited to `working-directory`. The `security-scan-blocking-severity` input is passed to every child scan. Its default `off` keeps scheduled scans report-only; setting it to `low`, `medium`, `high`, or `critical` makes findings at or above that severity fail the umbrella workflow, while below-threshold findings fail only the child policy job.
+Each matrix entry calls an internal stage workflow that first discovers the latest version for that stage/environment and then scans that exact version. The security-source-scan job runs in parallel with the per-stage matrices. For source scans, `secret-scan-scope: full-history` applies to repository-wide TruffleHog git scanning; Trivy scans the current checked-out branch tree and is not limited to `working-directory`. The `security-scan-blocking-severity` input is passed to every child scan. Its default `off` keeps scheduled scans report-only; setting it to `low`, `medium`, `high`, or `critical` makes scanner failures and findings at or above that severity fail the umbrella workflow. Below-threshold findings are reported without failing policy jobs.
 
 ## Version discovery
 

--- a/docs/reference/p2p-workflow-source-security-scan.md
+++ b/docs/reference/p2p-workflow-source-security-scan.md
@@ -1,6 +1,6 @@
 # p2p-workflow-source-security-scan
 
-> Scans repository source for committed secrets and dependency vulnerabilities. Produces a workflow summary, optionally posts a sticky PR comment on `pull_request` events when permissions allow, and uploads a `security-source-scan-findings` artifact. The `security-source-policy` job fails on active vulnerability or secret findings; the configured blocking severity controls whether that policy failure fails the workflow.
+> Scans repository source for committed secrets and dependency vulnerabilities. Produces a workflow summary, optionally posts a sticky PR comment on `pull_request` events when permissions allow, and uploads a `security-source-scan-findings` artifact. The `security-source-policy` job fails only on findings at or above the configured blocking severity.
 
 ## Usage
 
@@ -13,7 +13,7 @@ Internal workflow called from [`p2p-workflow-fastfeedback`](p2p-workflow-fastfee
 | `secret-scan-scope` | string | Yes | - | `changes` for PR/push scanning or `full-history` for scheduled monitoring. TruffleHog uses this to choose git history scope. Trivy scans the current checked-out source tree. |
 | `app-name` | string | No | `''` | Application name used to scope sticky PR comments in multi-app repositories. It does not select source scanner scope or security ignore files. Primary P2P workflow templates pass this through. When omitted by direct callers, comment scope falls back to `tenant-name`, then `vars.TENANT_NAME`. |
 | `tenant-name` | string | No | `''` | Tenant identifier used as the sticky comment scope fallback when `app-name` is omitted. |
-| `blocking-severity` | string | No | `off` | Minimum finding severity that blocks the workflow: `off`, `low`, `medium`, `high`, or `critical`. When blocking is enabled, verified secrets are treated as `critical`. The `security-source-policy` job fails on active vulnerability or secret findings, but the workflow continues when findings are below the blocking threshold. |
+| `blocking-severity` | string | No | `off` | Minimum finding severity that blocks the workflow: `off`, `low`, `medium`, `high`, or `critical`. `off` is report-only and does not fail the workflow for findings or incomplete scanner output. When blocking is enabled, scanner output must be complete and verified secrets are treated as `critical`. |
 | `ignore-unfixed` | boolean | No | `true` | Passed to Trivy vulnerability scanning. |
 | `dry-run` | boolean | No | `false` | When `true`, skips scanner installs, scans, sticky PR comments, artifact upload, and policy enforcement. The summary reports that the scan was skipped. Dry-run still parses discovered `.p2p-security-ignore.yaml` files, so a malformed ignore file can fail report generation. |
 | `checkout-version` | string | No | `''` | Git ref to check out before scanning. Ignored when `dry-run` is `true`; the workflow checks out the default ref. |
@@ -62,10 +62,11 @@ See [How to ignore security findings](../how-to/ignore-security-findings.md) for
 
 ## Blocking policy
 
-The workflow is visibility-first by default. Scanner setup or execution errors always fail the workflow. Finding policy is controlled by `blocking-severity`:
+The workflow is visibility-first by default. Finding and scanner-status policy is controlled by `blocking-severity`:
 
-- `off`: findings do not fail the workflow, but the `security-source-policy` job fails when vulnerabilities or secrets are found;
-- `low`, `medium`, `high`, or `critical`: reported Trivy vulnerability findings below that threshold fail only the `security-source-policy` job, while findings at or above that threshold fail the workflow;
+- `off`: findings and incomplete scanner output are reported but do not fail policy jobs or the workflow;
+- `low`, `medium`, `high`, or `critical`: scanner setup or execution errors fail the workflow because the policy cannot make a definite threshold decision;
+- reported Trivy vulnerability findings below the threshold are reported but do not fail the policy job, while findings at or above the threshold fail the workflow;
 - verified TruffleHog secrets are treated as `critical` findings and fail the workflow for any non-`off` threshold.
 
 ## See also

--- a/docs/tutorials/getting-started.md
+++ b/docs/tutorials/getting-started.md
@@ -121,7 +121,7 @@ See [Pipeline model](../explanation/pipeline-model.md) for the full picture of h
 
 ## Security scans
 
-Fast-feedback also calls source security scanning and image scanning automatically on each pull request and push. Source security scanning covers source dependency vulnerabilities and git-tree secrets. Image scanning covers both known CVEs and embedded secrets. At this level, `security-scan-blocking-severity` defaults to `off`, so the scans report findings without blocking the workflow by default.
+Fast-feedback also calls source security scanning and image scanning automatically on each pull request and push. Source security scanning covers source dependency vulnerabilities and git-tree secrets. Image scanning covers both known CVEs and embedded secrets. At this level, `security-scan-blocking-severity` defaults to `off`, so the scans report findings and scanner issues without blocking the workflow by default.
 
 Look in the workflow summary and uploaded artifact for the details, and on pull requests you'll also get a sticky comment with the latest results.
 See [Image scanning](../explanation/image-scanning.md), [Secrets scanning](../explanation/secrets-scanning.md), and [Triage security findings](../how-to/triage-security-findings.md) for what each scan checks and how to respond.


### PR DESCRIPTION
## Summary
- Treat blocking-severity=off as report-only for scanner status-policy jobs
- Stop failing source/image policy jobs for non-blocking findings
- Update tests and docs to reflect report-only off behavior