### PR TITLE
Add agent worktree guidance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .idea/
 .history/
 .vscode/
+.worktrees/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,6 @@
+# AGENTS.md
+
+## Branching and worktrees
+
+- Use a git worktree under `.worktrees/` for all changes; do not work directly on `main`.
+- Before committing, run `git status` or `git branch --show-current` and confirm you are not on `main`.


### PR DESCRIPTION
## Summary
- Add AGENTS.md with instructions to use git worktrees under .worktrees/.
- Ignore local .worktrees/ directories.

## Test Plan
- Verified .worktrees/ is ignored with git check-ignore.
- Verified AGENTS.md contains worktree guidance.