### PR TITLE
Invert PR integration test flag

### DIFF
--- a/.github/workflows/internal-ci.yaml
+++ b/.github/workflows/internal-ci.yaml
@@ -56,6 +56,7 @@ jobs:
         TEST_VARIABLE=value
     with:
       dry-run: true
+      run-fastfeedback-integration-on-prs: true
       version: ${{ needs.test_version.outputs.version }}
 
   test_source_security_scan:

--- a/.github/workflows/p2p-workflow-fastfeedback.yaml
+++ b/.github/workflows/p2p-workflow-fastfeedback.yaml
@@ -51,7 +51,7 @@ on:
         required: false
         type: string
         default: '.'
-      skip-fastfeedback-integration-on-prs:
+      run-fastfeedback-integration-on-prs:
         required: false
         type: boolean
         default: false
@@ -200,7 +200,7 @@ jobs:
 
   integration-test:
     needs: [functional-test, nft-test]
-    if: success() && ( !inputs.skip-fastfeedback-integration-on-prs || github.ref == inputs.main-branch || github.ref_type == 'tag' )
+    if: success() && ( inputs.run-fastfeedback-integration-on-prs || github.ref == inputs.main-branch || github.ref_type == 'tag' )
     uses: ./.github/workflows/p2p-execute-command.yaml
     secrets:
       env_vars: ${{ secrets.env_vars }}

--- a/docs/explanation/pipeline-model.md
+++ b/docs/explanation/pipeline-model.md
@@ -108,7 +108,7 @@ The three stages run as separate workflows, connected by the image registry:
 
 Each stage serves a distinct purpose and runs on its own schedule:
 
-- **Fast-feedback validates every change.** It runs on every pull request and every merge to `main`, keeping the development loop short. Promotion to the integration registry is configurable: restrict it to merges to `main` for a stable integration environment, or allow it on PR pushes too for faster integrated testing at the cost of more churn. See `skip-fastfeedback-integration-on-prs` in the [fast-feedback reference](../reference/p2p-workflow-fastfeedback.md).
+- **Fast-feedback validates every change.** It runs on every pull request and every merge to `main`, keeping the development loop short. Promotion to the integration registry is restricted to merges to `main` and tag pushes. Integration testing on PR pushes is configurable for faster integrated testing at the cost of more churn. See `run-fastfeedback-integration-on-prs` in the [fast-feedback reference](../reference/p2p-workflow-fastfeedback.md).
 - **Extended-test exercises expensive or long-running behaviour.** These tests run on a schedule (typically overnight) against the latest version that passed fast-feedback. Running them once per day for a known-good version controls cost and cluster load while still catching deeper issues.
 - **Prod deploys on a predictable cadence.** A daily morning schedule takes the most recent well-tested version — from extended-test if configured, or from fast-feedback otherwise — and deploys it. A predictable deployment window means issues surface when the team is available to respond.
 
@@ -122,7 +122,7 @@ Promotions only occur when:
 - For fast-feedback: the workflow is running on the `main` branch or a tag push.
 - For extended-test and prod: the workflow is running on `main` (enforced by the workflow's own trigger — cron and `workflow_dispatch` always run against the default branch).
 
-On PR branches, fast-feedback runs `p2p-build`, `p2p-functional`, `p2p-nft`, and optionally `p2p-integration` (skippable via `skip-fastfeedback-integration-on-prs`), but never promotes.
+On PR branches, fast-feedback runs `p2p-build`, `p2p-functional`, `p2p-nft`, and optionally `p2p-integration` (enabled via `run-fastfeedback-integration-on-prs`), but never promotes.
 
 ## Concurrency behaviour
 

--- a/docs/how-to/skip-stages-on-prs.md
+++ b/docs/how-to/skip-stages-on-prs.md
@@ -1,6 +1,6 @@
 # How to Skip Stages on Pull Requests
 
-Two inputs let you reduce what runs on pull requests: `dry-run` skips cloud authentication and build tool invocation entirely, and `skip-fastfeedback-integration-on-prs` skips integration tests on PRs while keeping them on `main` and tag pushes.
+Two inputs control what runs on pull requests: `dry-run` skips cloud authentication and build tool invocation entirely, and `run-fastfeedback-integration-on-prs` opts pull requests into integration tests. Integration tests always run on `main` and tag pushes.
 
 ## 1. Use `dry-run` for syntax testing
 
@@ -14,21 +14,21 @@ fastfeedback:
     dry-run: true
 ```
 
-## 2. Skip integration tests on PRs
+## 2. Enable integration tests on PRs
 
-Set `skip-fastfeedback-integration-on-prs: true` to skip integration tests when the workflow runs on a pull request. Integration tests still run on pushes to `main` and on tag pushes.
+Integration tests are skipped on pull requests by default. Set `run-fastfeedback-integration-on-prs: true` to run integration tests when the workflow runs on a pull request.
 
 ```yaml
 fastfeedback:
   uses: coreeng/p2p/.github/workflows/p2p-workflow-fastfeedback.yaml@v1
   with:
     version: ${{ needs.version.outputs.version }}
-    skip-fastfeedback-integration-on-prs: true
+    run-fastfeedback-integration-on-prs: true
 ```
 
-## 3. Combine both inputs
+## 3. Skip cloud work and integration tests on PRs
 
-Use `dry-run` and `skip-fastfeedback-integration-on-prs` together. A common pattern is to enable `dry-run` only on PRs using a conditional expression while also skipping integration tests:
+Use `dry-run` by itself when you want fast PR syntax feedback without cloud access or integration tests:
 
 ```yaml
 fastfeedback:
@@ -36,7 +36,6 @@ fastfeedback:
   with:
     version: ${{ needs.version.outputs.version }}
     dry-run: ${{ github.event_name == 'pull_request' }}
-    skip-fastfeedback-integration-on-prs: true
 ```
 
 This gives fast PR feedback without requiring cloud access, while still running the full pipeline on `main`.

--- a/docs/reference/p2p-workflow-fastfeedback.md
+++ b/docs/reference/p2p-workflow-fastfeedback.md
@@ -43,7 +43,7 @@ Grant `pull-requests: write` when the workflow runs on pull requests so source a
 | `source` | `string` | No | `${{ vars.FAST_FEEDBACK }}` | JSON matrix of deploy environments for the fast-feedback stage. |
 | `destination` | `string` | No | `${{ vars.EXTENDED_TEST }}` | JSON matrix of deploy environments to promote to after integration tests pass. |
 | `working-directory` | `string` | No | `.` | Repository path from which make targets are executed. |
-| `skip-fastfeedback-integration-on-prs` | `boolean` | No | `false` | When `true`, skips the `integration-test` job on pull requests (runs unconditionally on main or tags). |
+| `run-fastfeedback-integration-on-prs` | `boolean` | No | `false` | When `true`, runs the `integration-test` job on pull requests. Integration tests always run on main or tags. |
 | `skip-subnamespaces-create` | `boolean` | No | `false` | Skips creating subnamespaces before running make targets. |
 | `artifacts` | `string` | No | `''` | YAML-formatted map of make target names to artifact paths. Paths matching each active command are uploaded after that command runs. |
 | `security-scan-blocking-severity` | `string` | No | `off` | Minimum security finding severity that blocks the workflow: `off`, `low`, `medium`, `high`, or `critical`. When blocking is enabled, verified secrets are treated as `critical`. Policy jobs fail only for blocking findings unless `security-scan-fail-on-non-blocking-findings` is enabled. |
@@ -73,8 +73,9 @@ build
 ├── functional-test   (needs: build)
 └── nft-test          (needs: build)
     └── integration-test  (needs: functional-test, nft-test)
-                          Skipped when skip-fastfeedback-integration-on-prs=true
-                          AND ref is not main-branch AND ref_type is not tag.
+                          Skipped on pull requests unless
+                          run-fastfeedback-integration-on-prs=true.
+                          Always runs on main-branch or tag pushes.
         └── promote       (needs: integration-test, security-image-scan, security-source-scan)
                           Runs only on main-branch or tag pushes.
 

--- a/docs/tutorials/getting-started.md
+++ b/docs/tutorials/getting-started.md
@@ -108,12 +108,12 @@ In the GitHub Actions UI you'll see:
    - `security-source-scan` runs independently of `build`.
    - `security-image-scan` runs once `build` succeeds.
    - `functional-test` and `nft-test` run in parallel once build succeeds.
-   - `integration-test` runs after both `functional-test` and `nft-test` succeed.
+   - `integration-test` runs after both `functional-test` and `nft-test` succeed on `main`, tags, or PRs that opt in.
    - `promote` runs last (on `main` only), after `integration-test`, `security-image-scan`, and `security-source-scan` have all succeeded, and copies the image into the `EXTENDED_TEST` registry path.
 
 ## What happens next
 
-On a pull request, the pipeline runs build, functional, nft, and integration tests but skips promote. On a push to `main`, promote runs and the next pipeline stage can pull the image.
+On a pull request, the pipeline runs build, functional, and nft tests, skips integration tests by default, and skips promote. On a push to `main`, integration tests and promote run, and the next pipeline stage can pull the image.
 
 The `p2p-nft` and `p2p-integration` targets are optional. Define them only when you need them; the pipeline exits those steps successfully and continues when they are absent.
 


### PR DESCRIPTION
## Summary
- replace skip-fastfeedback-integration-on-prs input with run-fastfeedback-integration-on-prs, invert the default