### PR TITLE
Fix actionlint shellcheck warnings

### DIFF
--- a/.github/workflows/internal-cd.yaml
+++ b/.github/workflows/internal-cd.yaml
@@ -27,5 +27,5 @@ jobs:
         run: |
           curl -v -X POST https://api.github.com/repos/coreeng/p2p-testing/dispatches \
           -H 'Accept: application/vnd.github.everest-preview+json' \
-          -u ${ACCESS_TOKEN} \
+          -u "${ACCESS_TOKEN}" \
           --data '{"event_type": "trigger", "client_payload": { "action": "trigger" }}'

--- a/.github/workflows/internal-version.yaml
+++ b/.github/workflows/internal-version.yaml
@@ -64,9 +64,11 @@ jobs:
       id: setversion
       shell: bash
       run: |
-        echo "patch=${{ steps.semvers.outputs.patch }}" >> "$GITHUB_OUTPUT"
-        echo "minor=${{ steps.semvers.outputs.patch }}" | cut -d. -f1,2 >> "$GITHUB_OUTPUT"
-        echo "major=${{ steps.semvers.outputs.patch }}" | cut -d. -f1 >> "$GITHUB_OUTPUT"
+        {
+          echo "patch=${{ steps.semvers.outputs.patch }}"
+          echo "minor=${{ steps.semvers.outputs.patch }}" | cut -d. -f1,2
+          echo "major=${{ steps.semvers.outputs.patch }}" | cut -d. -f1
+        } >> "$GITHUB_OUTPUT"
 
     - name: Show the tags
       shell: bash

--- a/.github/workflows/p2p-version.yaml
+++ b/.github/workflows/p2p-version.yaml
@@ -67,8 +67,9 @@ jobs:
       shell: bash
       env:
         VERSION_PREFIX: ${{ inputs.version-prefix }}
+        PREVIOUS_TAG: ${{ steps.previoustag.outputs.tag }}
       run: |
-        echo "version=$(echo ${{ steps.previoustag.outputs.tag }} | awk -F ${VERSION_PREFIX} '{print $2}')" >> "$GITHUB_OUTPUT"
+        echo "version=${PREVIOUS_TAG#"$VERSION_PREFIX"}" >> "$GITHUB_OUTPUT"
 
     - name: Get next patch version
       id: semvers
@@ -81,14 +82,14 @@ jobs:
       shell: bash
       env:
         VERSION_PREFIX: ${{ inputs.version-prefix }}
+        PREVIOUS_VERSION: ${{ steps.previousversion.outputs.version }}
       run: |
         GIT_REF="HEAD"
-        PREVIOUS_TAG=${{ steps.previousversion.outputs.version }}
         if [ -n "$GITHUB_HEAD_REF" ]; then
             GIT_REF="origin/$GITHUB_HEAD_REF"
         fi
-        HASH=$(git rev-parse ${GIT_REF})
-        LAST_TAG_HASH=$(git rev-list -n 1 ${VERSION_PREFIX}${PREVIOUS_TAG} || echo "does-not-exist" )
+        HASH=$(git rev-parse "${GIT_REF}")
+        LAST_TAG_HASH=$(git rev-list -n 1 "${VERSION_PREFIX}${PREVIOUS_VERSION}" || echo "does-not-exist" )
 
         echo "current_hash=${HASH}" >> "$GITHUB_OUTPUT"
         echo "previous_tag_hash=${LAST_TAG_HASH}" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary
- quote shell variables flagged by SC2086 in workflow scripts
- avoid unquoted tag parsing by passing GitHub expressions through env
- group repeated GITHUB_OUTPUT redirects to resolve SC2129