### PR TITLE
Filter Yarn checksum secret false positives

### DIFF
--- a/.github/scripts/source-secret-redact.js
+++ b/.github/scripts/source-secret-redact.js
@@ -12,6 +12,16 @@ const pathToUrlPath = file => String(file || '')
   .map(segment => encodeURIComponent(segment))
   .join('/');
 
+const isYarnChecksumFalsePositive = finding => {
+  const detector = finding.DetectorName || finding.DetectorType;
+  const raw = finding.RawV2 || finding.Raw || '';
+  const file = finding.SourceMetadata?.Data?.Git?.file || '';
+
+  return detector === 'FlatIO'
+    && /(^|\/)yarn\.lock$/.test(file)
+    && /^[0-9a-f]{128}$/.test(raw);
+};
+
 const redactFinding = (finding, { serverUrl, repository }) => {
   const detector = finding.DetectorName || finding.DetectorType || 'unknown';
   const git = finding.SourceMetadata?.Data?.Git || {};
@@ -50,6 +60,7 @@ const redactSourceSecrets = ({ inputPath, outputPath, serverUrl, repository }) =
     } catch (error) {
       throw new Error(`Failed to process TruffleHog source finding ${inputPath}: ${error.message}`);
     }
+    if (isYarnChecksumFalsePositive(finding)) continue;
     fs.appendFileSync(outputPath, `${JSON.stringify(redactFinding(finding, { serverUrl, repository }))}\n`);
   }
 };

--- a/.github/scripts/tests/source-secret-redaction.test.js
+++ b/.github/scripts/tests/source-secret-redaction.test.js
@@ -56,6 +56,26 @@ fs.writeFileSync(input, [
     RawV2: rawV2OnlySecretB,
     SourceMetadata: { Data: { Git: {} } },
   }),
+  JSON.stringify({
+    DetectorName: 'FlatIO',
+    Raw: 'a'.repeat(128),
+    SourceMetadata: { Data: { Git: { file: 'web/yarn.lock' } } },
+  }),
+  JSON.stringify({
+    DetectorName: 'FlatIO',
+    Raw: 'z'.repeat(128),
+    SourceMetadata: { Data: { Git: { file: 'web/yarn.lock' } } },
+  }),
+  JSON.stringify({
+    DetectorName: 'FlatIO',
+    Raw: 'b'.repeat(128),
+    SourceMetadata: { Data: { Git: { file: 'web/package-lock.json' } } },
+  }),
+  JSON.stringify({
+    DetectorName: 'Generic',
+    Raw: 'c'.repeat(128),
+    SourceMetadata: { Data: { Git: { file: 'web/yarn.lock' } } },
+  }),
   '',
 ].join('\n'));
 
@@ -76,7 +96,7 @@ assert(!redactedText.includes(rawV2OnlySecretA));
 assert(!redactedText.includes(rawV2OnlySecretB));
 
 const findings = redactedText.trim().split('\n').map(line => JSON.parse(line));
-assert.strictEqual(findings.length, 5);
+assert.strictEqual(findings.length, 8);
 
 const expectedId = crypto.createHash('sha256').update(`Github\0${rawSecret}`).digest('hex');
 assert.deepStrictEqual(findings[0], {
@@ -89,7 +109,7 @@ assert.deepStrictEqual(findings[0], {
   url: 'https://github.example/org/repo/blob/abcdef1234567890/docs/secrets%20file%2Bname.env#L7',
 });
 
-const rawV2Ids = findings.slice(3).map(finding => finding.id);
+const rawV2Ids = findings.slice(3, 5).map(finding => finding.id);
 assert.strictEqual(new Set(rawV2Ids).size, 2);
 assert.deepStrictEqual(rawV2Ids, [
   crypto.createHash('sha256').update(`Generic\0${rawV2OnlySecretA}`).digest('hex'),
@@ -99,5 +119,10 @@ assert.strictEqual(findings[1].status, 'unknown');
 assert.strictEqual(findings[1].detector, 'Slack');
 assert.strictEqual(findings[1].url, null);
 assert.strictEqual(findings[2].status, 'unverified');
+assert.deepStrictEqual(findings.slice(5).map(finding => finding.detector), [
+  'FlatIO',
+  'FlatIO',
+  'Generic',
+]);
 
 console.log('source secret redaction fixtures passed');


### PR DESCRIPTION
## Summary
- suppress FlatIO findings only when the matched value is a 128-character hexadecimal checksum in a Yarn lockfile
- retain FlatIO findings with non-hex values and all findings in other files
- cover suppressed and retained cases in the source-secret redaction fixtures

This filters the deterministic checksum findings exposed by the Yarn 4 template update in coreeng/core-platform-software-templates#201.

## Testing
- `node .github/scripts/tests/source-secret-redaction.test.js`
- `node .github/scripts/tests/source-security-ignore-report.test.js`
- scanned the affected Next.js lockfile with TruffleHog 3.95.9 and confirmed both findings are filtered from the redacted report