### PR TITLE
Use core-platform-infra runtime image

### DIFF
--- a/.github/workflows/platform-execute-command.yaml
+++ b/.github/workflows/platform-execute-command.yaml
@@ -61,7 +61,7 @@ jobs:
       pull-requests: write
 
     container:
-      image:  ghcr.io/coreeng/core-platform:${{ inputs.release }}
+      image:  ghcr.io/coreeng/core-platform-infra:${{ inputs.release }}
       credentials:
         username: ${{ secrets.cecg-registry-username }}
         password: ${{ secrets.cecg-registry-secret }}


### PR DESCRIPTION
## Summary
- pull platform command containers from `ghcr.io/coreeng/core-platform-infra`
- retain existing workflow inputs and product naming

## Verification
- `actionlint .github/workflows/platform-execute-command.yaml`
- `git diff --check`

## Coordination
Do not merge or advance the maintained `v1` ref until a matching runtime release has been published to `ghcr.io/coreeng/core-platform-infra`.