### PR TITLE
Fail multi-image promotion on copy errors

### DIFF
--- a/.github/scripts/tests/promotion-fail-fast.test.sh
+++ b/.github/scripts/tests/promotion-fail-fast.test.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+test_dir="$(mktemp -d)"
+trap 'rm -rf "${test_dir}"' EXIT
+
+mkdir -p "${test_dir}/bin"
+
+cat >"${test_dir}/bin/skopeo" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+printf '%s\n' "$*" >>"${SKOPEO_LOG}"
+if [[ "$*" == *"/${SKOPEO_FAILURE_IMAGE}:"* ]]; then
+  exit 42
+fi
+EOF
+chmod +x "${test_dir}/bin/skopeo"
+
+test_promotion_target() {
+  local target="$1"
+  local source_path="$2"
+  local destination_path="$3"
+  local log_file="${test_dir}/${target}.log"
+
+  if PATH="${test_dir}/bin:${PATH}" \
+    SKOPEO_LOG="${log_file}" \
+    SKOPEO_FAILURE_IMAGE="second" \
+    make --no-print-directory -f "${repo_root}/p2p.mk" \
+      P2P_IMAGE_NAMES="first second third" \
+      P2P_VERSION="1.2.3" \
+      SOURCE_REGISTRY="source.example" \
+      REGISTRY="destination.example" \
+      "${target}"; then
+    printf '%s\n' "${target} unexpectedly succeeded" >&2
+    exit 1
+  fi
+
+  calls=()
+  while IFS= read -r call; do
+    calls+=("${call}")
+  done <"${log_file}"
+  if [[ "${#calls[@]}" -ne 2 ]]; then
+    printf '%s\n' "${target} made ${#calls[@]} copy attempts; expected 2" >&2
+    exit 1
+  fi
+  local expected_first="copy --all --preserve-digests docker://source.example/${source_path}/first:1.2.3 docker://destination.example/${destination_path}/first:1.2.3"
+  local expected_second="copy --all --preserve-digests docker://source.example/${source_path}/second:1.2.3 docker://destination.example/${destination_path}/second:1.2.3"
+  if [[ "${calls[0]}" != "${expected_first}" || "${calls[1]}" != "${expected_second}" ]]; then
+    printf '%s\n' "${target} attempted images in an unexpected order" >&2
+    exit 1
+  fi
+  if [[ "${calls[*]}" == *"/third:1.2.3"* ]]; then
+    printf '%s\n' "${target} continued after the failed image" >&2
+    exit 1
+  fi
+}
+
+test_promotion_target p2p-promote-to-extended-test fast-feedback extended-test
+test_promotion_target p2p-promote-to-prod extended-test prod

--- a/.github/workflows/internal-ci.yaml
+++ b/.github/workflows/internal-ci.yaml
@@ -114,6 +114,13 @@ jobs:
           assert 'github.workspace' not in workflow
           PY
 
+  test_promotion_failure_handling:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v6
+      - name: Test multi-image promotion failure handling
+        run: bash .github/scripts/tests/promotion-fail-fast.test.sh
+
   test_image_scan:
     needs: [test_version]
     strategy:

--- a/p2p.mk
+++ b/p2p.mk
@@ -104,11 +104,12 @@ p2p-images:
 
 .PHONY: p2p-promote-to-extended-test ## Promote to extended test
 p2p-promote-to-extended-test:
-	$(foreach image, $(P2P_IMAGE_NAMES), \
+	@for image in $(P2P_IMAGE_NAMES); do \
 		skopeo copy --all --preserve-digests \
-			docker://$(SOURCE_REGISTRY)/$(P2P_REGISTRY_FAST_FEEDBACK_PATH)/$(image):$(P2P_VERSION) \
-			docker://$(REGISTRY)/$(P2P_REGISTRY_EXTENDED_TEST_PATH)/$(image):$(P2P_VERSION) \
-	;)
+			docker://$(SOURCE_REGISTRY)/$(P2P_REGISTRY_FAST_FEEDBACK_PATH)/$${image}:$(P2P_VERSION) \
+			docker://$(REGISTRY)/$(P2P_REGISTRY_EXTENDED_TEST_PATH)/$${image}:$(P2P_VERSION) \
+			|| exit $$?; \
+	done
 
 .PHONY: p2p-extended-test ## Run extended tests
 %-extended-test: p2p_app_url_suffix=-extended
@@ -120,11 +121,12 @@ p2p-promote-to-extended-test:
 
 .PHONY: p2p-promote-to-prod ## Promote to prod
 p2p-promote-to-prod:
-	$(foreach image, $(P2P_IMAGE_NAMES), \
+	@for image in $(P2P_IMAGE_NAMES); do \
 		skopeo copy --all --preserve-digests \
-			docker://$(SOURCE_REGISTRY)/$(P2P_REGISTRY_EXTENDED_TEST_PATH)/$(image):$(P2P_VERSION) \
-			docker://$(REGISTRY)/$(P2P_REGISTRY_PROD_PATH)/$(image):$(P2P_VERSION) \
-	;)
+			docker://$(SOURCE_REGISTRY)/$(P2P_REGISTRY_EXTENDED_TEST_PATH)/$${image}:$(P2P_VERSION) \
+			docker://$(REGISTRY)/$(P2P_REGISTRY_PROD_PATH)/$${image}:$(P2P_VERSION) \
+			|| exit $$?; \
+	done
 
 .PHONY: p2p-prod ## Deploy to prod
 %-prod: p2p_app_url_suffix=


### PR DESCRIPTION
## Summary
- replace semicolon-separated multi-image promotion commands with a fail-fast shell loop
- stop promotion immediately when any image copy fails, preserving the failing target status
- add regression coverage for both fast-feedback to extended-test and extended-test to production promotion

## Verification
- `bash .github/scripts/tests/promotion-fail-fast.test.sh`
- `bash -n .github/scripts/tests/promotion-fail-fast.test.sh`
- `mise exec -- shellcheck .github/scripts/tests/promotion-fail-fast.test.sh`
- `mise exec -- actionlint`
- `git diff --check`